### PR TITLE
Activation du cache docker pour le build Maven

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,16 @@ RUN sed -i '/fr_FR.UTF-8/s/^# //g' /etc/locale.gen && \
 ENV LANG fr_FR.UTF-8
 ENV LANGUAGE fr_FR:fr
 ENV LC_ALL fr_FR.UTF-8
-# On lance la compilation
-# si on a un .m2 local on peut décommenter la ligne suivante pour 
-# éviter à maven de retélécharger toutes les dépendances
-#COPY ./.m2/    /root/.m2/
+
+
+# On lance la compilation Java
+# On débute par une mise en cache des dépendances Java
+# cf https://www.baeldung.com/ops/docker-cache-maven-dependencies
 COPY ./pom.xml /build/pom.xml
+COPY ./core/pom.xml /build/core/pom.xml
+COPY ./web/pom.xml /build/web/pom.xml
+RUN mvn verify --fail-never
+# et la compilation du code Java
 COPY ./core/   /build/core/
 COPY ./web/    /build/web/
 RUN mvn --batch-mode \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV LC_ALL fr_FR.UTF-8
 
 
 # On lance la compilation Java
-# On débute par une mise en cache des dépendances Java
+# On débute par une mise en cache docker des dépendances Java
 # cf https://www.baeldung.com/ops/docker-cache-maven-dependencies
 COPY ./pom.xml /build/pom.xml
 COPY ./core/pom.xml /build/core/pom.xml


### PR DESCRIPTION
Cette modification permet d'accélérer le build de l'image docker par la mise en cache des dépendances Maven (qui peuvent prendre pas mal de temps à être téléchargées).

Cette optimisation est utile quand on veut tester l'image en local et qu'on a besoin de compiler le code N fois et générer l'image docker N fois. On passe alors d'une création d'image qui prend 120 secondes (avant mise en cache) à une création d'image qui prend 40 secondes une fois la mise en cache appliquée.

A suivre dans une autre PR : une mise à jour du README qui montre la commande docker qui permet de builder en local l'image qualimarc-api