### PR TITLE
ODS-347 : Fix : Correction méthode sélection des règles

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/service/RuleService.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/service/RuleService.java
@@ -181,14 +181,14 @@ public class RuleService {
                 if (ruleSet != null)
                     ruleSet.forEach(r -> rulesRuleSet.addAll(complexRulesRepository.findByRuleSet(r)));
 
-                if (!rulesRuleSet.isEmpty())
-                    if (rulesTypes.isEmpty())
-                        return rulesRuleSet;
-                    else
-                        //on retourne l'intersection entre la liste contenant les règles par familles de doc et celle par jeux de règles personnalisés
-                        return rulesTypes.stream().filter(rulesRuleSet::contains).collect(Collectors.toSet());
-                else
-                    return rulesTypes;
+                if (!rulesRuleSet.isEmpty() && !rulesTypes.isEmpty()) {
+                    //on retourne l'intersection entre la liste contenant les règles par familles de doc et celle par jeux de règles personnalisés
+                    return rulesTypes.stream().filter(rulesRuleSet::contains).collect(Collectors.toSet());
+                }
+                if(!rulesRuleSet.isEmpty())
+                    return rulesRuleSet;
+
+                return rulesTypes;
             default:
                 throw new IllegalRulesSetException("Jeu de règle inconnu");
         }

--- a/core/src/test/java/fr/abes/qualimarc/core/service/RuleServiceTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/service/RuleServiceTest.java
@@ -331,13 +331,13 @@ public class RuleServiceTest {
     void checkRulesOnNoticesFocusedTypeDoc() {
         Set<FamilleDocument> typesDoc = new HashSet<>();
         typesDoc.add(new FamilleDocument("B", "Audiovisuel"));
-        Set<ComplexRule> rules = new HashSet<>();
-        rules.add(new ComplexRule(1, "Zone 010 obligatoire", Priority.P1, typesDoc, Sets.newHashSet(), null, new PresenceZone(1, "010", true)));
+        Set<ComplexRule> rulesIn = new HashSet<>();
+        rulesIn.add(new ComplexRule(1, "Zone 010 obligatoire", Priority.P1, typesDoc, Sets.newHashSet(), null, new PresenceZone(1, "010", true)));
 
-        Mockito.when(complexRulesRepository.findByFamillesDocuments(Mockito.any())).thenReturn(rules);
+        Mockito.when(complexRulesRepository.findByFamillesDocuments(Mockito.any())).thenReturn(rulesIn);
 
         Set<ComplexRule> result = service.getResultRulesList(TypeAnalyse.FOCUSED, typesDoc, null,null);
-        Assertions.assertIterableEquals(result, rules);
+        Assertions.assertTrue(result.size() == rulesIn.size() && result.containsAll(rulesIn) && rulesIn.containsAll(result));
     }
 
     /**
@@ -346,19 +346,19 @@ public class RuleServiceTest {
     @Test
     void checkRulesOnNoticesFocusedRuleSet() {
         RuleSet ruleSet = new RuleSet(1, "Zones 210/214 (publication, production, diffusion)");
-        Set<ComplexRule> rules = new HashSet<>();
+        Set<ComplexRule> rulesIn = new HashSet<>();
         ComplexRule rule = new ComplexRule(1, "Zone 010 obligatoire", Priority.P1, new PresenceZone(1, "010", true));
         rule.addRuleSet(ruleSet);
-        rules.add(rule);
+        rulesIn.add(rule);
 
-        Mockito.when(complexRulesRepository.findByRuleSet(ruleSet)).thenReturn(rules);
+        Mockito.when(complexRulesRepository.findByRuleSet(ruleSet)).thenReturn(rulesIn);
 
         Set<RuleSet> ruleSets = new HashSet<>();
         ruleSets.add(ruleSet);
 
         Set<ComplexRule> result = service.getResultRulesList(TypeAnalyse.FOCUSED, null, null, ruleSets);
         //les listes ne contenant qu'un élément on utilise assertIterableEquals pour vérifier qu'elles sont identiques
-        Assertions.assertIterableEquals(result, rules);
+        Assertions.assertTrue(result.size() == rulesIn.size() && result.containsAll(rulesIn) && rulesIn.containsAll(result));
     }
 
     /**
@@ -366,18 +366,19 @@ public class RuleServiceTest {
      */
     @Test
     void checkRulesOnNoticesFocusedTypeThese() {
-        Set<ComplexRule> rules = new HashSet<>();
+        Set<ComplexRule> rulesIn = new HashSet<>();
         ComplexRule rule = new ComplexRule(1, "Zone 010 obligatoire", Priority.P1, new PresenceZone(1, "010", true));
         rule.addTypeThese(TypeThese.REPRO);
-        rules.add(rule);
+        rulesIn.add(rule);
 
-        Mockito.when(complexRulesRepository.findByTypesThese(TypeThese.REPRO)).thenReturn(rules);
+        Mockito.when(complexRulesRepository.findByTypesThese(TypeThese.REPRO)).thenReturn(rulesIn);
+
         Set<TypeThese> typeTheseSet = new HashSet<>();
         typeTheseSet.add(TypeThese.REPRO);
 
         Set<ComplexRule> result = service.getResultRulesList(TypeAnalyse.FOCUSED, null, typeTheseSet, null);
         //les listes ne contenant qu'un élément on utilise assertIterableEquals pour vérifier qu'elles sont identiques
-        Assertions.assertIterableEquals(result, rules);
+        Assertions.assertTrue(result.size() == rulesIn.size() && result.containsAll(rulesIn) && rulesIn.containsAll(result));
     }
 
     /**
@@ -395,15 +396,16 @@ public class RuleServiceTest {
 
         //déclaration du set de rule utilisé pour vérifier le résultat de l'appel à la méthode testée
         Set<ComplexRule> rulesIn = new HashSet<>();
-        rulesIn.add(rule1);
         rulesIn.add(rule2);
-        Set<ComplexRule> rules = new HashSet<>();
-        rule1.addRuleSet(ruleSet);
-        rules.add(rule1);
 
-        Mockito.when(complexRulesRepository.findByRuleSet(ruleSet)).thenReturn(rules);
+        //jeu de règle retourné par la récupération des règles par jeu de règle personnalisé
+        Set<ComplexRule> rulesRuleSet = new HashSet<>();
+        rulesRuleSet.add(rule1);
+        rulesRuleSet.add(rule2);
 
+        Mockito.when(complexRulesRepository.findByRuleSet(ruleSet)).thenReturn(rulesRuleSet);
 
+        //jeu de règle retourné par la récupération des règles par familles de documents
         Set<ComplexRule> rulesType = new HashSet<>();
         rulesType.add(rule2);
 
@@ -413,6 +415,44 @@ public class RuleServiceTest {
         ruleSets.add(ruleSet);
 
         Set<ComplexRule> result = service.getResultRulesList(TypeAnalyse.FOCUSED, typesDoc, null, ruleSets);
+
+        Assertions.assertTrue(result.size() == rulesIn.size() && result.containsAll(rulesIn) && rulesIn.containsAll(result));
+    }
+
+    /**
+     * Teste le cas d'une analyse ciblée avec jeu de règles et familles de documents de type thèse
+     */
+    @Test
+    void checkRulesOnNoticesFocusedTypeTheseRuleSet() {
+        RuleSet ruleSet = new RuleSet(1, "Zones 210/214 (publication, production, diffusion)");
+
+        ComplexRule rule1 = new ComplexRule(1, "Zone 010 obligatoire", Priority.P1, new PresenceZone(1, "010", true));
+        ComplexRule rule2 = new ComplexRule(2, "Zone 200 obligatoire", Priority.P1, new PresenceZone(2, "200", true));
+
+        //déclaration du set de rule utilisé pour vérifier le résultat de l'appel à la méthode testée
+        Set<ComplexRule> rulesIn = new HashSet<>();
+        rulesIn.add(rule2);
+
+        //jeu de règle retourné par la récupération des règles par jeu de règle personnalisé
+        Set<ComplexRule> rulesRuleSet = new HashSet<>();
+        rulesRuleSet.add(rule1);
+        rulesRuleSet.add(rule2);
+
+        Mockito.when(complexRulesRepository.findByRuleSet(ruleSet)).thenReturn(rulesRuleSet);
+
+        //jeu de règle retourné par la récupération des règles par familles de documents
+        Set<ComplexRule> rulesTypeThese = new HashSet<>();
+        rulesTypeThese.add(rule2);
+
+        Mockito.when(complexRulesRepository.findByTypesThese(Mockito.any())).thenReturn(rulesTypeThese);
+
+        Set<RuleSet> ruleSets = new HashSet<>();
+        ruleSets.add(ruleSet);
+
+        Set<TypeThese> typeThese = new HashSet<>();
+        typeThese.add(TypeThese.REPRO);
+
+        Set<ComplexRule> result = service.getResultRulesList(TypeAnalyse.FOCUSED, null, typeThese, ruleSets);
 
         Assertions.assertTrue(result.size() == rulesIn.size() && result.containsAll(rulesIn) && rulesIn.containsAll(result));
     }


### PR DESCRIPTION
-  ajustement algo en faisant une intersection sur les listes de règles par famille et par jeu de règle personnalisé
- gestion des cas ou l'une ou l'autre des listes est vide
- Ajout TU et ajustement des TU existants