### PR TITLE
Soa 183 évolution règle presence chaine caracteres

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteres.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteres.java
@@ -39,6 +39,12 @@ public class PresenceChaineCaracteres extends SimpleRule implements Serializable
     @Enumerated(EnumType.STRING)
     private TypeVerification typeDeVerification;
 
+    @Column(name = "POSITIONSTART")
+    private Integer positionStart;
+
+    @Column(name = "POSITIONEND")
+    private Integer positionEnd;
+
     @OneToMany(mappedBy = "presenceChaineCaracteres", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<ChaineCaracteres> listChainesCaracteres;
 
@@ -72,6 +78,16 @@ public class PresenceChaineCaracteres extends SimpleRule implements Serializable
         this.listChainesCaracteres = listChainesCaracteres;
     }
 
+    public PresenceChaineCaracteres(Integer id, String zone, Boolean affichageEtiquette, String sousZone, Integer positionStart, Integer positionEnd, TypeVerification typeDeVerification) {
+        super(id, zone, affichageEtiquette);
+        this.sousZone = sousZone;
+        this.positionStart = positionStart;
+        this.positionEnd = positionEnd;
+        this.typeDeVerification = typeDeVerification;
+        this.listChainesCaracteres = new TreeSet<>();
+    }
+
+
     /**
      * Méthode qui ajoute une chaine de caractères à la liste de chaines de caractères
      * @param chaine chaine de caractères à rechercher
@@ -97,7 +113,19 @@ public class PresenceChaineCaracteres extends SimpleRule implements Serializable
         }
 
         // Récupération de la liste des zones qui MATCH avec la règle
-        List<Datafield> zonesValid = zones.stream().filter(datafield -> datafield.getSubFields().stream().anyMatch(subField -> (subField.getCode().equals(sousZone)) && isValueValidWithChaineCaracteres(subField.getValue(), typeDeVerification))).collect(Collectors.toList());
+        List<Datafield> zonesValid = null;
+        if (positionStart == null && positionEnd == null) {
+            zonesValid = zones.stream().filter(datafield -> datafield.getSubFields().stream().anyMatch(subField -> (subField.getCode().equals(sousZone)) && isValueValidWithChaineCaracteres(subField.getValue(), typeDeVerification))).collect(Collectors.toList());
+        }
+        if (positionStart != null && positionEnd == null) {
+            zonesValid = zones.stream().filter(datafield -> datafield.getSubFields().stream().anyMatch(subField -> (subField.getCode().equals(sousZone)) && isValueValidWithChaineCaracteres(subField.getValue().substring(positionStart), typeDeVerification))).collect(Collectors.toList());
+        }
+        if (positionStart == null && positionEnd != null) {
+            zonesValid = zones.stream().filter(datafield -> datafield.getSubFields().stream().anyMatch(subField -> (subField.getCode().equals(sousZone)) && isValueValidWithChaineCaracteres(subField.getValue().substring(0, positionEnd+1), typeDeVerification))).collect(Collectors.toList());
+        }
+        if (positionStart != null && positionEnd != null) {
+            zonesValid = zones.stream().filter(datafield -> datafield.getSubFields().stream().anyMatch(subField -> (subField.getCode().equals(sousZone)) && isValueValidWithChaineCaracteres(subField.getValue().substring(positionStart, positionEnd+1), typeDeVerification))).collect(Collectors.toList());
+        }
 
         if (this.getComplexRule() != null && this.getComplexRule().isMemeZone()){
             this.getComplexRule().setSavedZone(zonesValid);

--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteres.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteres.java
@@ -155,7 +155,7 @@ public class PresenceChaineCaracteres extends SimpleRule implements Serializable
     private boolean isValueValidWithChaineCaracteres(String value, TypeVerification typeDeVerification) {
         Boolean isOk = null;
         TreeSet<ChaineCaracteres> orderedListChaine = new TreeSet<>(listChainesCaracteres);
-        for( ChaineCaracteres chaineCaractere : orderedListChaine) {
+        for(ChaineCaracteres chaineCaractere : orderedListChaine) {
             boolean isValid = chaineCaractere.isValid(value, typeDeVerification);
             if(isOk == null) {
                 isOk = isValid;

--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/chainecaracteres/ChaineCaracteres.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/chainecaracteres/ChaineCaracteres.java
@@ -64,7 +64,7 @@ public class ChaineCaracteres implements Comparable {
     }
 
     public boolean isValid(String value, TypeVerification typeVerification){
-        value = (value != null) ? value : ""; //meme traitement de null que si c'etait une chaine vide
+        value = (value != null) ? value.replaceAll("[| #]","[VIDE]") : ""; //meme traitement de null que si c'etait une chaine vide
         switch (typeVerification) {
             case STRICTEMENT:
                 return value.equals(chaineCaracteres);

--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/chainecaracteres/ChaineCaracteres.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/chainecaracteres/ChaineCaracteres.java
@@ -6,6 +6,7 @@ import fr.abes.qualimarc.core.utils.TypeVerification;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Setter
 @NoArgsConstructor
+@Slf4j
 @Table(name = "CHAINE_CARACTERES")
 public class ChaineCaracteres implements Comparable {
 
@@ -65,6 +67,7 @@ public class ChaineCaracteres implements Comparable {
 
     public boolean isValid(String value, TypeVerification typeVerification){
         value = (value != null) ? value.replaceAll("[| #]","[VIDE]") : ""; //meme traitement de null que si c'etait une chaine vide
+        chaineCaracteres = (chaineCaracteres != null) ? chaineCaracteres.replaceAll("[| #]","[VIDE]") : "";
         switch (typeVerification) {
             case STRICTEMENT:
                 return value.equals(chaineCaracteres);

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteresTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteresTest.java
@@ -341,6 +341,42 @@ public class PresenceChaineCaracteresTest {
     }
 
     @Test
+    @DisplayName("Controle d'une chaîne de caractère sur une plage de positions spécifiée")
+    void isValid25() {
+        ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "fre", null);
+        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(1, "100",true, "a", 22, 24, TypeVerification.STRICTEMENT);
+        rule.addChaineCaracteres(chaineCaracteres);
+        Assertions.assertTrue(rule.isValid(notice));
+    }
+
+    @Test
+    @DisplayName("Controle d'une chaîne de caractère sur une plage de positions spécifiée avec la mauvaise borne de fin")
+    void isValid27() {
+        ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "fre", null);
+        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(1, "100",true, "a", 22, 29, TypeVerification.STRICTEMENT);
+        rule.addChaineCaracteres(chaineCaracteres);
+        Assertions.assertFalse(rule.isValid(notice));
+    }
+
+    @Test
+    @DisplayName("Controle d'une chaîne de caractère sur une position de début spécifiée, mais sans position de fin spécifiée")
+    void isValid28() {
+        ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "fre", null);
+        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(1, "100",true, "a", 22, null, TypeVerification.CONTIENT);
+        rule.addChaineCaracteres(chaineCaracteres);
+        Assertions.assertTrue(rule.isValid(notice));
+    }
+
+    @Test
+    @DisplayName("Controle d'une chaîne de caractère sur une position de fin spécifiée, mais sans position de début spécifiée")
+    void isValid29() {
+        ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "fre", null);
+        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(1, "100",true, "a", null, 24, TypeVerification.CONTIENT);
+        rule.addChaineCaracteres(chaineCaracteres);
+        Assertions.assertTrue(rule.isValid(notice));
+    }
+
+    @Test
     @DisplayName("test getZones")
     void getZones() {
         ChaineCaracteres chaineCaracteres = new ChaineCaracteres();

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteresTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteresTest.java
@@ -396,10 +396,10 @@ public class PresenceChaineCaracteresTest {
     }
 
     @Test
-    @DisplayName("test sur zone 110")
+    @DisplayName("test sur zone 110 de recherche d'un caractère vide à la position 7")
     void isValid32() {
         ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "[VIDE]", null);
-        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(2, "110", true, "a", 4, 4, TypeVerification.STRICTEMENT);
+        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(2, "110", true, "a", 7, 7, TypeVerification.STRICTEMENT);
         rule.addChaineCaracteres(chaineCaracteres);
         Assertions.assertTrue(rule.isValid(notice));
     }

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteresTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteresTest.java
@@ -392,13 +392,17 @@ public class PresenceChaineCaracteresTest {
         ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "[VIDE][VIDE][VIDE]", null);
         PresenceChaineCaracteres rule = new PresenceChaineCaracteres(1, "105",true, "a", 0, 2, TypeVerification.STRICTEMENT);
         rule.addChaineCaracteres(chaineCaracteres);
-
         Assertions.assertTrue(rule.isValid(notice));
     }
 
-
-
-
+    @Test
+    @DisplayName("test sur zone 110")
+    void isValid32() {
+        ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "[VIDE]", null);
+        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(2, "110", true, "a", 4, 4, TypeVerification.STRICTEMENT);
+        rule.addChaineCaracteres(chaineCaracteres);
+        Assertions.assertTrue(rule.isValid(notice));
+    }
 
     @Test
     @DisplayName("test getZones")

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteresTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/contenu/PresenceChaineCaracteresTest.java
@@ -377,6 +377,30 @@ public class PresenceChaineCaracteresTest {
     }
 
     @Test
+    @DisplayName("test détection de caractères vides dans une sous zone")
+    void isValid30() {
+        ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "[VIDE]", null);
+        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(1, "105",true, "a", TypeVerification.CONTIENT);
+        rule.addChaineCaracteres(chaineCaracteres);
+
+        Assertions.assertTrue(rule.isValid(notice));
+    }
+
+    @Test
+    @DisplayName("test détection de trois premiers caractères vides dans une sous zone")
+    void isValid31() {
+        ChaineCaracteres chaineCaracteres = new ChaineCaracteres(1, "[VIDE][VIDE][VIDE]", null);
+        PresenceChaineCaracteres rule = new PresenceChaineCaracteres(1, "105",true, "a", 0, 2, TypeVerification.STRICTEMENT);
+        rule.addChaineCaracteres(chaineCaracteres);
+
+        Assertions.assertTrue(rule.isValid(notice));
+    }
+
+
+
+
+
+    @Test
     @DisplayName("test getZones")
     void getZones() {
         ChaineCaracteres chaineCaracteres = new ChaineCaracteres();

--- a/core/src/test/resources/092850324.xml
+++ b/core/src/test/resources/092850324.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+    <leader>     ccd0 22        450 </leader>
+    <controlfield tag="001">092850324</controlfield>
+    <controlfield tag="003">https://www.sudoc.fr/092850324</controlfield>
+    <controlfield tag="004">20051122</controlfield>
+    <controlfield tag="005">20201110194821.000</controlfield>
+    <controlfield tag="006">590092238</controlfield>
+    <controlfield tag="007">1999</controlfield>
+    <controlfield tag="008">Mdx3</controlfield>
+    <datafield tag="100" ind1="#" ind2="#">
+        <subfield code="a">20051122f19      m  y0frey50      ba</subfield>
+    </datafield>
+    <datafield tag="101" ind1="0" ind2="#">
+        <subfield code="a">hun</subfield>
+        <subfield code="2">639-2</subfield>
+    </datafield>
+    <datafield tag="102" ind1="#" ind2="#">
+        <subfield code="a">HU</subfield>
+    </datafield>
+    <datafield tag="104" ind1="#" ind2="#">
+        <subfield code="a">m</subfield>
+        <subfield code="b">y</subfield>
+        <subfield code="c">y</subfield>
+        <subfield code="d">ba</subfield>
+        <subfield code="e">0</subfield>
+        <subfield code="f">fre</subfield>
+    </datafield>
+    <datafield tag="110" ind1="#" ind2="#">
+        <subfield code="a">by|||||0xx0</subfield>
+    </datafield>
+    <datafield tag="181" ind1="#" ind2="#">
+        <subfield code="6">z01</subfield>
+        <subfield code="c">ntm</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="181" ind1="#" ind2="1">
+        <subfield code="6">z01</subfield>
+        <subfield code="a">d#</subfield>
+        <subfield code="b">axxe##</subfield>
+    </datafield>
+    <datafield tag="182" ind1="#" ind2="#">
+        <subfield code="6">z01</subfield>
+        <subfield code="c">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="182" ind1="#" ind2="1">
+        <subfield code="6">z01</subfield>
+        <subfield code="a">n</subfield>
+    </datafield>
+    <datafield tag="200" ind1="0" ind2="#">
+        <subfield code="a">Musica sacra</subfield>
+        <subfield code="d">= Gedrückte Musik</subfield>
+    </datafield>
+    <datafield tag="210" ind1="#" ind2="#">
+        <subfield code="a">Budapest</subfield>
+        <subfield code="c">Editio Musica</subfield>
+        <subfield code="d">[19??]-</subfield>
+    </datafield>
+    <datafield tag="215" ind1="#" ind2="#">
+        <subfield code="d">27 cm</subfield>
+    </datafield>
+    <datafield tag="301" ind1="#" ind2="#">
+        <subfield code="a">Demande de numérotation ISSN en cours par le CR 49</subfield>
+    </datafield>
+    <datafield tag="303" ind1="#" ind2="#">
+        <subfield code="a">Notice rédigée d&apos;après un vol. publié en 1974</subfield>
+    </datafield>
+    <datafield tag="326" ind1="#" ind2="#">
+        <subfield code="a">Collection</subfield>
+    </datafield>
+    <datafield tag="530" ind1="1" ind2="#">
+        <subfield code="a">Musica sacra</subfield>
+        <subfield code="b">(Budapest)</subfield>
+    </datafield>
+    <datafield tag="801" ind1="#" ind2="3">
+        <subfield code="a">FR</subfield>
+        <subfield code="b">Abes</subfield>
+        <subfield code="c">20201110</subfield>
+        <subfield code="g">AFNOR</subfield>
+    </datafield>
+</record>

--- a/core/src/test/resources/143519379.xml
+++ b/core/src/test/resources/143519379.xml
@@ -46,6 +46,9 @@
     <datafield tag="106" ind1=" " ind2=" ">
         <subfield code="a">r</subfield>
     </datafield>
+    <datafield tag="110" ind1="#" ind2="#">
+        <subfield code="a">by|@@|| xx0</subfield>
+    </datafield>
     <datafield tag="181" ind1=" " ind2=" ">
         <subfield code="6">z01</subfield>
         <subfield code="c">txt</subfield>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
     <!-- =========================================================== -->
     <!--     Configuration de la compilation                         -->

--- a/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/contenu/PresenceChaineCaracteresWebDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/contenu/PresenceChaineCaracteresWebDto.java
@@ -35,6 +35,12 @@ public class PresenceChaineCaracteresWebDto extends SimpleRuleWebDto {
     @JsonProperty("chaines-caracteres")
     private List<ChaineCaracteresWebDto> listChaineCaracteres;
 
+    @JsonProperty("positionstart")
+    private Integer positionStart;
+
+    @JsonProperty("positionend")
+    private Integer positionEnd;
+
     /**
      * Constructeur sans liste de chaines de caractères
      * @param id identifiant de la règle
@@ -47,6 +53,48 @@ public class PresenceChaineCaracteresWebDto extends SimpleRuleWebDto {
      * @param typeDeVerifications type de vérification à appliquer pour la règle
      */
     public PresenceChaineCaracteresWebDto(Integer id, Integer idExcel, List<Integer> ruleSetList, String message,  boolean affichageEtiquette, String zone, String priority, List<String> typesDoc, List<String> typesThese, String sousZone, String typeDeVerifications, List<ChaineCaracteresWebDto> listChaineCaracteres) {
+        super(id, idExcel, ruleSetList, message, affichageEtiquette, zone, priority, typesDoc, typesThese);
+        this.sousZone = sousZone;
+        this.typeDeVerification = typeDeVerifications;
+        this.listChaineCaracteres = listChaineCaracteres;
+    }
+
+    /**
+     * Constructeur sans liste de chaines de caractères
+     * @param id identifiant de la règle
+     * @param idExcel identifiant excel de la règle
+     * @param message message à renvoyer si la règle est vérifiée
+     * @param zone zone sur laquelle appliquer la règle
+     * @param priority priorité de la règle
+     * @param typesDoc type de document de la notice sur laquelle appliquer la règle
+     * @param sousZone sous-zone sur laquelle appliquer la règle
+     * @param positionStart position dans la sous-zone où commence le contrôle
+     * @param positionEnd position dans la sous-zone où s'arrête le contrôle
+     * @param typeDeVerifications type de vérification à appliquer pour la règle
+     */
+    public PresenceChaineCaracteresWebDto(Integer id, Integer idExcel, List<Integer> ruleSetList, String message,  boolean affichageEtiquette, String zone, String priority, List<String> typesDoc, List<String> typesThese, String sousZone, Integer positionStart, Integer positionEnd, String typeDeVerifications, List<ChaineCaracteresWebDto> listChaineCaracteres) {
+        super(id, idExcel, ruleSetList, message, affichageEtiquette, zone, priority, typesDoc, typesThese);
+        this.sousZone = sousZone;
+        this.positionStart = positionStart;
+        this.positionEnd = positionEnd;
+        this.typeDeVerification = typeDeVerifications;
+        this.listChaineCaracteres = listChaineCaracteres;
+    }
+
+    /**
+     * Constructeur sans liste de chaines de caractères
+     * @param id identifiant de la règle
+     * @param idExcel identifiant excel de la règle
+     * @param message message à renvoyer si la règle est vérifiée
+     * @param zone zone sur laquelle appliquer la règle
+     * @param priority priorité de la règle
+     * @param typesDoc type de document de la notice sur laquelle appliquer la règle
+     * @param sousZone sous-zone sur laquelle appliquer la règle
+     * @param positionstart position dans la sous-zone où commence le contrôle
+     * @param positionend position dans la sous-zone où s'arrête le contrôle
+     * @param typeDeVerifications type de vérification à appliquer pour la règle
+     */
+    public PresenceChaineCaracteresWebDto(Integer id, Integer idExcel, List<Integer> ruleSetList, String message, boolean affichageEtiquette, String zone, String priority, List<String> typesDoc, List<String> typesThese, String sousZone, String typeDeVerifications, Integer positionStart, Integer positionEnd, List<ChaineCaracteresWebDto> listChaineCaracteres) {
         super(id, idExcel, ruleSetList, message, affichageEtiquette, zone, priority, typesDoc, typesThese);
         this.sousZone = sousZone;
         this.typeDeVerification = typeDeVerifications;

--- a/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/contenu/PresenceChaineCaracteresWebDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/contenu/PresenceChaineCaracteresWebDto.java
@@ -90,13 +90,15 @@ public class PresenceChaineCaracteresWebDto extends SimpleRuleWebDto {
      * @param priority priorité de la règle
      * @param typesDoc type de document de la notice sur laquelle appliquer la règle
      * @param sousZone sous-zone sur laquelle appliquer la règle
-     * @param positionstart position dans la sous-zone où commence le contrôle
-     * @param positionend position dans la sous-zone où s'arrête le contrôle
+     * @param positionStart position dans la sous-zone où commence le contrôle
+     * @param positionEnd position dans la sous-zone où s'arrête le contrôle
      * @param typeDeVerifications type de vérification à appliquer pour la règle
      */
     public PresenceChaineCaracteresWebDto(Integer id, Integer idExcel, List<Integer> ruleSetList, String message, boolean affichageEtiquette, String zone, String priority, List<String> typesDoc, List<String> typesThese, String sousZone, String typeDeVerifications, Integer positionStart, Integer positionEnd, List<ChaineCaracteresWebDto> listChaineCaracteres) {
         super(id, idExcel, ruleSetList, message, affichageEtiquette, zone, priority, typesDoc, typesThese);
         this.sousZone = sousZone;
+        this.positionStart = positionStart;
+        this.positionEnd = positionEnd;
         this.typeDeVerification = typeDeVerifications;
         this.listChaineCaracteres = listChaineCaracteres;
     }

--- a/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/contenu/PresenceChaineCaracteresWebDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/contenu/PresenceChaineCaracteresWebDto.java
@@ -35,11 +35,17 @@ public class PresenceChaineCaracteresWebDto extends SimpleRuleWebDto {
     @JsonProperty("chaines-caracteres")
     private List<ChaineCaracteresWebDto> listChaineCaracteres;
 
-    @JsonProperty("positionstart")
-    private Integer positionStart;
+    @Pattern(regexp = "(\\b([0-9]{0,3})\\b)", message = "le champ position ne peut contenir que 3 chiffres au maximum.")
+    @JsonProperty("position")
+    private String position;
 
+    @Pattern(regexp = "(\\b([0-9]{0,3})\\b)", message = "le champ positionstart ne peut contenir que 3 chiffres au maximum.")
+    @JsonProperty("positionstart")
+    private String positionStart;
+
+    @Pattern(regexp = "(\\b([0-9]{0,3})\\b)", message = "le champ positionend ne peut contenir que 3 chiffres au maximum.")
     @JsonProperty("positionend")
-    private Integer positionEnd;
+    private String positionEnd;
 
     /**
      * Constructeur sans liste de chaines de caractères
@@ -72,7 +78,7 @@ public class PresenceChaineCaracteresWebDto extends SimpleRuleWebDto {
      * @param positionEnd position dans la sous-zone où s'arrête le contrôle
      * @param typeDeVerifications type de vérification à appliquer pour la règle
      */
-    public PresenceChaineCaracteresWebDto(Integer id, Integer idExcel, List<Integer> ruleSetList, String message,  boolean affichageEtiquette, String zone, String priority, List<String> typesDoc, List<String> typesThese, String sousZone, Integer positionStart, Integer positionEnd, String typeDeVerifications, List<ChaineCaracteresWebDto> listChaineCaracteres) {
+    public PresenceChaineCaracteresWebDto(Integer id, Integer idExcel, List<Integer> ruleSetList, String message,  boolean affichageEtiquette, String zone, String priority, List<String> typesDoc, List<String> typesThese, String sousZone, String positionStart, String positionEnd, String typeDeVerifications, List<ChaineCaracteresWebDto> listChaineCaracteres) {
         super(id, idExcel, ruleSetList, message, affichageEtiquette, zone, priority, typesDoc, typesThese);
         this.sousZone = sousZone;
         this.positionStart = positionStart;
@@ -94,9 +100,10 @@ public class PresenceChaineCaracteresWebDto extends SimpleRuleWebDto {
      * @param positionEnd position dans la sous-zone où s'arrête le contrôle
      * @param typeDeVerifications type de vérification à appliquer pour la règle
      */
-    public PresenceChaineCaracteresWebDto(Integer id, Integer idExcel, List<Integer> ruleSetList, String message, boolean affichageEtiquette, String zone, String priority, List<String> typesDoc, List<String> typesThese, String sousZone, String typeDeVerifications, Integer positionStart, Integer positionEnd, List<ChaineCaracteresWebDto> listChaineCaracteres) {
+    public PresenceChaineCaracteresWebDto(Integer id, Integer idExcel, List<Integer> ruleSetList, String message, boolean affichageEtiquette, String zone, String priority, List<String> typesDoc, List<String> typesThese, String sousZone, String typeDeVerifications, String position, String positionStart, String positionEnd, List<ChaineCaracteresWebDto> listChaineCaracteres) {
         super(id, idExcel, ruleSetList, message, affichageEtiquette, zone, priority, typesDoc, typesThese);
         this.sousZone = sousZone;
+        this.position = position;
         this.positionStart = positionStart;
         this.positionEnd = positionEnd;
         this.typeDeVerification = typeDeVerifications;

--- a/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/contenu/PresenceChaineCaracteresWebDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/contenu/PresenceChaineCaracteresWebDto.java
@@ -15,6 +15,11 @@ import java.util.List;
 /**
  * Classe WebDto qui définie une règle permettant de tester la présence d'une zone et sous-zone ainsi que la présence,
  * la position ou la conformité d'une ou plusieurs chaines de caractères dans une sous-zone.
+ *
+ * Indexation des positions:
+ * - Les champs positionstart et positionend sont en index base 0.
+ * - 0 correspond au premier caractere.
+ * - Exemple: positionstart=3 et positionend=3 cible le 4e caractere.
  */
 @Getter
 @Setter
@@ -39,10 +44,12 @@ public class PresenceChaineCaracteresWebDto extends SimpleRuleWebDto {
     @JsonProperty("position")
     private String position;
 
+    // Index base 0: 0 = premier caractere.
     @Pattern(regexp = "(\\b([0-9]{0,3})\\b)", message = "le champ positionstart ne peut contenir que 3 chiffres au maximum.")
     @JsonProperty("positionstart")
     private String positionStart;
 
+    // Index base 0: 0 = premier caractere.
     @Pattern(regexp = "(\\b([0-9]{0,3})\\b)", message = "le champ positionend ne peut contenir que 3 chiffres au maximum.")
     @JsonProperty("positionend")
     private String positionEnd;
@@ -191,6 +198,7 @@ public class PresenceChaineCaracteresWebDto extends SimpleRuleWebDto {
 Liste des champs propres au type de règle présence chaine caractères:
 * souszone : **obligatoire** - de type caractère. La sous-zone à vérifier. ATTENTION : le $ du format Unimarc de catalogage ne doit pas être renseigné
 * type-de-verification : **obligatoire** - ne peut être que `STRICTEMENT` ou `COMMENCE` ou `TERMINE` ou `CONTIENT` ou `NECONTIENTPAS`
+* positionstart/positionend : **optionnel** - indexation base 0 (0 = premier caractère). Pour cibler un seul caractère : positionstart = positionend
 * chaines-caracteres : **obligatoire** - de type liste d'objets. La liste des chaine-caracteres à vérifier. Les champs d'un objet de la liste sont les suivants :
     * operateur : de type opérateur logique. ne peut être que `ET` ou `OU`.
     * chaine-caracteres :  la chaine de caractères à vérifier

--- a/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
@@ -684,7 +684,7 @@ public class WebDtoMapper {
      * @return PresenceChaineCaracteres
      */
     private PresenceChaineCaracteres constructPresenceChaineCaracteres(PresenceChaineCaracteresWebDto source) {
-        PresenceChaineCaracteres target = new PresenceChaineCaracteres(source.getId(), source.getZone(), source.isAffichageEtiquette(), source.getSousZone(), getTypeDeVerification(source.getTypeDeVerification()));
+        PresenceChaineCaracteres target = new PresenceChaineCaracteres(source.getId(), source.getZone(), source.isAffichageEtiquette(), source.getSousZone(), source.getPositionStart(), source.getPositionEnd(), getTypeDeVerification(source.getTypeDeVerification()));
         if (source.getListChaineCaracteres() != null && !source.getListChaineCaracteres().isEmpty()) {
             int i = 0;
             for (PresenceChaineCaracteresWebDto.ChaineCaracteresWebDto chaine : source.getListChaineCaracteres()) {

--- a/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
@@ -406,7 +406,8 @@ public class WebDtoMapper {
     public void converterPresenceChaineCaracteresToLinkedRule() {
         Converter<PresenceChaineCaracteresWebDto, SimpleRule> myConverter = new Converter<PresenceChaineCaracteresWebDto, SimpleRule>() {
             public SimpleRule convert(MappingContext<PresenceChaineCaracteresWebDto, SimpleRule> context) {
-                return constructPresenceChaineCaracteres(context.getSource());
+                PresenceChaineCaracteresWebDto source = context.getSource();
+                    return constructPresenceChaineCaracteres(context.getSource());
             }
         };
         mapper.addConverter(myConverter);
@@ -760,7 +761,21 @@ public class WebDtoMapper {
      * @return PresenceChaineCaracteres
      */
     private PresenceChaineCaracteres constructPresenceChaineCaracteres(PresenceChaineCaracteresWebDto source) {
-        PresenceChaineCaracteres target = new PresenceChaineCaracteres(source.getId(), source.getZone(), source.isAffichageEtiquette(), source.getSousZone(), source.getPositionStart(), source.getPositionEnd(), getTypeDeVerification(source.getTypeDeVerification()));
+        Integer positionStart = convertStringToInteger(source.getPositionStart());
+        Integer positionEnd = convertStringToInteger(source.getPositionEnd());
+        Integer position = convertStringToInteger(source.getPosition());
+        if((positionStart != null || positionEnd != null) && position != null) {
+            throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut position ne peut pas etre present en meme temps que positionstart ou positionend");
+        }
+        if(positionStart != null && positionEnd != null && positionStart > positionEnd) {
+            throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstart ne peut pas etre plus grand que positionend");
+        }
+        PresenceChaineCaracteres target;
+        if(position != null){
+            target = new PresenceChaineCaracteres(source.getId(), source.getZone(), source.isAffichageEtiquette(), source.getSousZone(), position, position, getTypeDeVerification(source.getTypeDeVerification()));
+        }else{
+            target = new PresenceChaineCaracteres(source.getId(), source.getZone(), source.isAffichageEtiquette(), source.getSousZone(), positionStart, positionEnd, getTypeDeVerification(source.getTypeDeVerification()));
+        }
         if (source.getListChaineCaracteres() != null && !source.getListChaineCaracteres().isEmpty()) {
             int i = 0;
             for (PresenceChaineCaracteresWebDto.ChaineCaracteresWebDto chaine : source.getListChaineCaracteres()) {

--- a/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
@@ -264,7 +264,7 @@ public class WebDtoMapper {
                     throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positioncible ne peut pas etre present en meme temps que positionstartcible ou positionendcible");
                 }
                 if(positionStart != null && positionEnd != null && positionStart > positionEnd) {
-                    throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstart ne peut pas etre plus grand que positionend");
+                    throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstart ne peut pas etre plus grand que positionend (indexation base 0)");
                 }
                 if(positionStartCible != null && positionEndCible != null && positionStartCible > positionEndCible) {
                     throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstartcible ne peut pas etre plus grand que positionendcible");
@@ -435,7 +435,7 @@ public class WebDtoMapper {
                     throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positioncible ne peut pas etre present en meme temps que positionstartcible ou positionendcible");
                 }
                 if(positionStart != null && positionEnd != null && positionStart > positionEnd) {
-                    throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstart ne peut pas etre plus grand que positionend");
+                    throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstart ne peut pas etre plus grand que positionend (indexation base 0)");
                 }
                 if(positionStartCible != null && positionEndCible != null && positionStartCible > positionEndCible) {
                     throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstartcible ne peut pas etre plus grand que positionendcible");
@@ -768,7 +768,7 @@ public class WebDtoMapper {
             throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut position ne peut pas etre present en meme temps que positionstart ou positionend");
         }
         if(positionStart != null && positionEnd != null && positionStart > positionEnd) {
-            throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstart ne peut pas etre plus grand que positionend");
+            throw new IllegalArgumentException("Règle " + source.getId() + " : L'attribut positionstart ne peut pas etre plus grand que positionend (indexation base 0)");
         }
         PresenceChaineCaracteres target;
         if(position != null){

--- a/web/src/main/resources/application-dev.properties
+++ b/web/src/main/resources/application-dev.properties
@@ -14,7 +14,6 @@ spring.jpa.qualimarc.hibernate.ddl-auto=create
 spring.jpa.qualimarc.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.sql.qualimarc.init.mode=always
 
-
 spring.datasource.basexml.jdbcurl=
 spring.datasource.basexml.username=
 spring.datasource.basexml.password=


### PR DESCRIPTION
Cette PR fait évoluer la règle presencechainecaracteres pour mieux gérer les contrôles par position et les cas de sous-zones vides, avec une couverture de tests adaptée.

  ## Modifications principales

  - Ajout/prise en charge des positions sur la règle presencechainecaracteres :                                                                                                                                                                       
      - support de positionStart / positionEnd                                                                                                                                                                                                        
      - support de l’attribut position côté WebDTO (ciblage d’une position unique)                                                                                                                                                                    
      - mapping de position vers un contrôle mono-caractère                                                                                                                                                                                           
  - Renforcement du mapper :                                                                                                                                                                                                                          
      - gestion des conflits entre position, positionStart, positionEnd                                                                                                                                                                               
      - validations associées pour éviter les combinaisons incohérentes
      - remplacement de la chaîne vide par le token [EMPTY] dans le traitement
      - correction d’un constructeur du PresenceChaineCaracteresWebDto
      - mise à jour de la documentation du PresenceChaineCaracteresWebDto

  ## Tests

      - contrôle d’un caractère à une position exacte
      - détection des caractères vides sur position/plage
      - cas null assimilés à vide
      - validations de conflit de paramètres de position

  ## Points d’attention en revue

  - Vérifier la cohérence fonctionnelle entre position et positionStart/positionEnd.                                                                                                                                                                  
  - Vérifier les messages d’erreur mapper sur cas de conflit.                                                                                                                                                                                         
  - Vérifier la compatibilité des règles déjà en base/fichiers YAML. 