### PR TITLE
[codex] Allow negative dependency positions

### DIFF
--- a/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/DependencyWebDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/DependencyWebDto.java
@@ -22,17 +22,17 @@ public class DependencyWebDto extends SimpleRuleWebDto {
     @NotNull(message = "Le champ type-notice-liee est obligatoire")
     private String typeNoticeLiee;
 
-    @Pattern(regexp = "(\\b([0-9]{0,3})\\b)", message = "le champ position ne peut contenir que 3 chiffres au maximum.")
+    @Pattern(regexp = "^-?[0-9]{1,3}$", message = "le champ position ne peut contenir qu'un entier signe de 3 chiffres au maximum.")
     @JsonProperty("position")
     private String position;
 
 
-    @Pattern(regexp = "(\\b([0-9]{0,3})\\b)", message = "le champ positionStart ne peut contenir que 3 chiffres au maximum.")
+    @Pattern(regexp = "^-?[0-9]{1,3}$", message = "le champ positionStart ne peut contenir qu'un entier signe de 3 chiffres au maximum.")
     @JsonProperty("positionStart")
     private String positionStart;
 
 
-    @Pattern(regexp = "(\\b([0-9]{0,3})\\b)", message = "le champ positionEnd ne peut contenir que 3 chiffres au maximum.")
+    @Pattern(regexp = "^-?[0-9]{1,3}$", message = "le champ positionEnd ne peut contenir qu'un entier signe de 3 chiffres au maximum.")
     @JsonProperty("positionEnd")
     private String positionEnd;
 

--- a/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
@@ -249,4 +249,36 @@ public class RuleControllerTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    @DisplayName("test creation regle complexe avec dependance et position negative")
+    void testIndexComplexRuleDependencyWithNegativePosition() throws Exception {
+        String yaml =
+                "---\n" +
+                "rules:\n" +
+                "   - id: 2\n" +
+                "     id-excel: 2\n" +
+                "     message: test dependance -1\n" +
+                "     priorite: P2\n" +
+                "     regles:\n" +
+                "       - id: 1\n" +
+                "         type: presencezone\n" +
+                "         zone: '606'\n" +
+                "         presence: true\n" +
+                "       - id: 2\n" +
+                "         type: dependance\n" +
+                "         zone: '606'\n" +
+                "         souszone: '3'\n" +
+                "         type-notice-liee: AUTORITE\n" +
+                "         position: -1\n" +
+                "       - id: 3\n" +
+                "         type: presencezone\n" +
+                "         zone: '200'\n" +
+                "         presence: true\n";
+
+        this.mockMvc.perform(post("/api/v1/indexComplexRules")
+                .contentType("application/x-yaml").characterEncoding(StandardCharsets.UTF_8)
+                .content(yaml).characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk());
+    }
+
 }

--- a/web/src/test/java/fr/abes/qualimarc/web/dto/indexrules/DependencyWebDtoValidationTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/dto/indexrules/DependencyWebDtoValidationTest.java
@@ -1,0 +1,37 @@
+package fr.abes.qualimarc.web.dto.indexrules;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class DependencyWebDtoValidationTest {
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("DependencyWebDto accepte les index negatifs documentes")
+    void validateSignedPositions() {
+        DependencyWebDto dependencyWebDto = new DependencyWebDto(1, "200", "a", "AUTORITE", "-1", "-2", "-1");
+
+        Set<ConstraintViolation<DependencyWebDto>> violations = validator.validate(dependencyWebDto);
+
+        Assertions.assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("DependencyWebDto rejette les positions non numeriques ou trop longues")
+    void rejectInvalidPositions() {
+        DependencyWebDto dependencyWebDto = new DependencyWebDto(1, "200", "a", "AUTORITE", "1a", "-1000", "abc");
+
+        Set<String> invalidProperties = validator.validate(dependencyWebDto).stream()
+                .map(violation -> violation.getPropertyPath().toString())
+                .collect(Collectors.toSet());
+
+        Assertions.assertEquals(Set.of("position", "positionStart", "positionEnd"), invalidProperties);
+    }
+}

--- a/web/src/test/java/fr/abes/qualimarc/web/mapper/WebDtoMapperTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/mapper/WebDtoMapperTest.java
@@ -1140,4 +1140,24 @@ public class WebDtoMapperTest {
         Assertions.assertEquals("L'identifiant du jeu de règles est obligatoire", exception.getCause().getMessage());
 
     }
+
+    @Test
+    @DisplayName("Test Mapper regle complexe avec regle de dependance et position negative")
+    void converterComplexRuleWithDependencyRuleAndNegativePosition() {
+        ComplexRuleWebDto complexRuleWebDto = new ComplexRuleWebDto();
+        complexRuleWebDto.setId(1);
+        complexRuleWebDto.setIdExcel(1);
+        complexRuleWebDto.setMessage("message test");
+        complexRuleWebDto.setPriority("P1");
+        complexRuleWebDto.addRegle(new PresenceZoneWebDto(1, "200", null, true));
+        complexRuleWebDto.addRegle(new DependencyWebDto(2, "200", "a", "AUTORITE", "-1", null, null));
+        complexRuleWebDto.addRegle(new PresenceZoneWebDto(3, "210", null, false));
+
+        ComplexRule complexRule = mapper.map(complexRuleWebDto, ComplexRule.class);
+
+        Assertions.assertTrue(complexRule.getOtherRules().get(0) instanceof DependencyRule);
+        DependencyRule dependencyRule = (DependencyRule) complexRule.getOtherRules().get(0);
+        Assertions.assertEquals(-1, dependencyRule.getPositionSousZoneSourceStart());
+        Assertions.assertEquals(-1, dependencyRule.getPositionSousZoneSourceEnd());
+    }
 }


### PR DESCRIPTION
## What changed
- allow signed integers on dependency position fields in the web DTO
- add mapper, validation, and controller coverage for \position: -1\

## Why
The rules README documented negative dependency positions, but the web API still rejected them.

## Validation
- mvn --% -pl web -am -Dtest=RuleControllerTest,WebDtoMapperTest,DependencyWebDtoValidationTest -Dsurefire.failIfNoSpecifiedTests=false test