### PR TITLE
SOA-182 : faire evoluer la regle POSITION DE SOUS-ZONE

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/GroupeMemeZone.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/GroupeMemeZone.java
@@ -1,0 +1,69 @@
+package fr.abes.qualimarc.core.model.entity.qualimarc.rules.structure;
+
+import fr.abes.qualimarc.core.model.entity.notice.NoticeXml;
+import fr.abes.qualimarc.core.model.entity.qualimarc.rules.ComplexRule;
+import fr.abes.qualimarc.core.model.entity.qualimarc.rules.LinkedRule;
+import fr.abes.qualimarc.core.model.entity.qualimarc.rules.SimpleRule;
+import fr.abes.qualimarc.core.utils.BooleanOperateur;
+import fr.abes.qualimarc.core.utils.Priority;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "RULE_GROUPEMEMEZONE")
+public class GroupeMemeZone extends SimpleRule implements Serializable {
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "ID_FIRST_RULE")
+    @NotNull
+    private SimpleRule firstRule;
+
+    @OneToMany(mappedBy = "groupeMemeZone", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @Fetch(FetchMode.JOIN)
+    private List<GroupeMemeZoneRegle> regles = new LinkedList<>();
+
+    public GroupeMemeZone(Integer id, String zone, Boolean affichageEtiquette, SimpleRule firstRule) {
+        super(id, zone, affichageEtiquette);
+        this.firstRule = firstRule;
+    }
+
+    public void addRegle(SimpleRule rule, BooleanOperateur operateur, Integer position) {
+        this.regles.add(new GroupeMemeZoneRegle(rule, operateur, position, this));
+    }
+
+    @Override
+    public boolean isValid(NoticeXml... notices) {
+        if (notices.length == 0 || this.firstRule == null) {
+            return false;
+        }
+
+        ComplexRule internalRule = new ComplexRule(this.id, "groupe-meme-zone", Priority.P1, this.firstRule);
+        internalRule.setMemeZone(true);
+
+        this.regles.stream()
+                .sorted(Comparator.comparing(GroupeMemeZoneRegle::getPosition))
+                .forEach(regle -> internalRule.addOtherRule(new LinkedRule(regle.getRule(), regle.getOperateur(), regle.getPosition(), internalRule)));
+
+        return internalRule.isValid(notices[0]);
+    }
+
+    @Override
+    public List<String> getZones() {
+        List<String> zones = new ArrayList<>(this.firstRule.getZones());
+        this.regles.forEach(regle -> zones.addAll(regle.getRule().getZones()));
+        return zones.stream().distinct().toList();
+    }
+}

--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/GroupeMemeZoneRegle.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/GroupeMemeZoneRegle.java
@@ -1,0 +1,48 @@
+package fr.abes.qualimarc.core.model.entity.qualimarc.rules.structure;
+
+import fr.abes.qualimarc.core.model.entity.qualimarc.rules.SimpleRule;
+import fr.abes.qualimarc.core.utils.BooleanOperateur;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "RULE_GROUPEMEMEZONE_REGLE")
+public class GroupeMemeZoneRegle implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "ID_GROUPEMEMEZONE")
+    private GroupeMemeZone groupeMemeZone;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "ID_RULE")
+    @NotNull
+    private SimpleRule rule;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "OPERATOR")
+    @NotNull
+    private BooleanOperateur operateur;
+
+    @Column(name = "POSITION")
+    @NotNull
+    private Integer position;
+
+    public GroupeMemeZoneRegle(SimpleRule rule, BooleanOperateur operateur, Integer position, GroupeMemeZone groupeMemeZone) {
+        this.rule = rule;
+        this.operateur = operateur;
+        this.position = position;
+        this.groupeMemeZone = groupeMemeZone;
+    }
+}

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/ComplexRuleTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/ComplexRuleTest.java
@@ -7,6 +7,7 @@ import fr.abes.qualimarc.core.model.entity.qualimarc.rules.contenu.Indicateur;
 import fr.abes.qualimarc.core.model.entity.qualimarc.rules.contenu.PresenceChaineCaracteres;
 import fr.abes.qualimarc.core.model.entity.qualimarc.rules.contenu.chainecaracteres.ChaineCaracteres;
 import fr.abes.qualimarc.core.model.entity.qualimarc.rules.dependance.Reciprocite;
+import fr.abes.qualimarc.core.model.entity.qualimarc.rules.structure.GroupeMemeZone;
 import fr.abes.qualimarc.core.model.entity.qualimarc.rules.structure.PositionSousZone;
 import fr.abes.qualimarc.core.model.entity.qualimarc.rules.structure.PresenceSousZone;
 import fr.abes.qualimarc.core.model.entity.qualimarc.rules.structure.PresenceZone;
@@ -33,6 +34,12 @@ public class ComplexRuleTest {
 
     @Value("classpath:02787088X.xml")
     private Resource xmlFileNoticeAutorite;
+
+    @Value("classpath:soa182-microfiche-invalid-328.xml")
+    private Resource xmlFileMicroficheInvalid328;
+
+    @Value("classpath:soa182-microfiche-valid-328.xml")
+    private Resource xmlFileMicroficheValid328;
 
     @Test
     @DisplayName("test méthode isValid règle complexe avec une seule règle simple")
@@ -609,6 +616,31 @@ public class ComplexRuleTest {
         complexRule2.addOtherRule(new LinkedRule(new PositionSousZone(3, "607", false, "3", Lists.newArrayList(positionsOperator), BooleanOperateur.OU), BooleanOperateur.ET, 0, complexRule2));
 
         Assertions.assertTrue(complexRule2.isValid(noticeBiblio));
+    }
+
+    @Test
+    @DisplayName("test groupe meme zone combine 215 microfiche et controle 328")
+    void testGroupeMemeZoneWithMicroficheRule() throws IOException {
+        JacksonXmlModule module = new JacksonXmlModule();
+        module.setDefaultUseWrapper(false);
+        XmlMapper mapper = new XmlMapper(module);
+
+        String xmlInvalid = IOUtils.toString(new FileInputStream(xmlFileMicroficheInvalid328.getFile()), StandardCharsets.UTF_8);
+        NoticeXml invalidNotice = mapper.readValue(xmlInvalid, NoticeXml.class);
+
+        String xmlValid = IOUtils.toString(new FileInputStream(xmlFileMicroficheValid328.getFile()), StandardCharsets.UTF_8);
+        NoticeXml validNotice = mapper.readValue(xmlValid, NoticeXml.class);
+
+        TreeSet<ChaineCaracteres> chaines = new TreeSet<>();
+        chaines.add(new ChaineCaracteres(1, "microfiche", null));
+
+        ComplexRule complexRule = new ComplexRule(9200, "test", Priority.P1, new PresenceChaineCaracteres(9201, "215", false, "a", TypeVerification.CONTIENT, chaines));
+        PositionsOperator positionsOperator = new PositionsOperator(1, 1, ComparaisonOperateur.DIFFERENT);
+        GroupeMemeZone groupeMemeZone = new GroupeMemeZone(9202, "328", false, new PositionSousZone(9203, "328", false, "z", Lists.newArrayList(positionsOperator), BooleanOperateur.OU));
+        complexRule.addOtherRule(new LinkedRule(groupeMemeZone, BooleanOperateur.ET, 0, complexRule));
+
+        Assertions.assertTrue(complexRule.isValid(invalidNotice));
+        Assertions.assertFalse(complexRule.isValid(validNotice));
     }
 
         @Test

--- a/core/src/test/resources/soa182-microfiche-invalid-328.xml
+++ b/core/src/test/resources/soa182-microfiche-invalid-328.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+    <leader>00000nam0 2200000   450 </leader>
+    <controlfield tag="001">soa182-invalid</controlfield>
+    <datafield tag="215" ind1=" " ind2=" ">
+        <subfield code="a">1 microfiche</subfield>
+        <subfield code="d">11 x 15 cm</subfield>
+    </datafield>
+    <datafield tag="328" ind1=" " ind2=" ">
+        <subfield code="b">Thèse</subfield>
+        <subfield code="z">Reproduction</subfield>
+        <subfield code="c">Informatique</subfield>
+    </datafield>
+</record>

--- a/core/src/test/resources/soa182-microfiche-valid-328.xml
+++ b/core/src/test/resources/soa182-microfiche-valid-328.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+    <leader>00000nam0 2200000   450 </leader>
+    <controlfield tag="001">soa182-valid</controlfield>
+    <datafield tag="215" ind1=" " ind2=" ">
+        <subfield code="a">1 microfiche</subfield>
+        <subfield code="d">11 x 15 cm</subfield>
+    </datafield>
+    <datafield tag="328" ind1=" " ind2=" ">
+        <subfield code="z">Reproduction</subfield>
+        <subfield code="b">Thèse</subfield>
+        <subfield code="c">Informatique</subfield>
+    </datafield>
+</record>

--- a/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/SimpleRuleWebDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/SimpleRuleWebDto.java
@@ -25,6 +25,7 @@ import java.util.List;
         @JsonSubTypes.Type(value = NombreSousZoneWebDto.class, name = "nombresouszone"),
         @JsonSubTypes.Type(value = PositionSousZoneWebDto.class, name="positionsouszone"),
         @JsonSubTypes.Type(value = PresenceSousZonesMemeZoneWebDto.class, name="presencesouszonesmemezone"),
+        @JsonSubTypes.Type(value = SameZoneRuleGroupWebDto.class, name="groupememezone"),
         @JsonSubTypes.Type(value = IndicateurWebDto.class, name="indicateur"),
         @JsonSubTypes.Type(value = NombreCaracteresWebDto.class, name = "nombrecaractere"),
         @JsonSubTypes.Type(value = TypeCaractereWebDto.class, name = "typecaractere"),

--- a/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/structure/SameZoneRuleGroupWebDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/structure/SameZoneRuleGroupWebDto.java
@@ -1,0 +1,29 @@
+package fr.abes.qualimarc.web.dto.indexrules.structure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import fr.abes.qualimarc.web.dto.indexrules.SimpleRuleWebDto;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonTypeName("groupememezone")
+public class SameZoneRuleGroupWebDto extends SimpleRuleWebDto {
+    @JsonProperty("regles")
+    @NotNull(message = "Le groupe meme zone doit contenir au moins une regle")
+    @NotEmpty(message = "Le groupe meme zone doit contenir au moins une regle")
+    private List<SimpleRuleWebDto> regles = new LinkedList<>();
+
+    public SameZoneRuleGroupWebDto(Integer id, String zone, String booleanOperator, List<SimpleRuleWebDto> regles) {
+        super(id, zone, booleanOperator);
+        this.regles = regles;
+    }
+}

--- a/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
@@ -389,6 +389,19 @@ public class WebDtoMapper {
     }
 
     /**
+     * Convertion d'un modÃ¨le SameZoneRuleGroupWebDto en modÃ¨le SimpleRule (LinkedRule)
+     */
+    @PostConstruct
+    public void converterSameZoneRuleGroupToLinkedRule() {
+        Converter<SameZoneRuleGroupWebDto, SimpleRule> myConverter = new Converter<SameZoneRuleGroupWebDto, SimpleRule>() {
+            public SimpleRule convert(MappingContext<SameZoneRuleGroupWebDto, SimpleRule> context) {
+                return constructGroupeMemeZone(context.getSource());
+            }
+        };
+        mapper.addConverter(myConverter);
+    }
+
+    /**
      * Convertion d'un modèle TypeCaractereWebDto en modèle SimpleRule (LinkedRule)
      */
     @PostConstruct
@@ -977,5 +990,36 @@ public class WebDtoMapper {
         if(rule.getZone() != null){
             throw new IllegalArgumentException("Les règles complexe ne peuvent pas contenir de règles simples avec des zones différentes");
         }
+    }
+    private GroupeMemeZone constructGroupeMemeZone(SameZoneRuleGroupWebDto source) {
+        if (source.getZone() == null) {
+            throw new IllegalArgumentException("RÃ¨gle " + source.getId() + " : La zone est obligatoire pour un groupe meme zone");
+        }
+        if (source.getRegles() == null || source.getRegles().isEmpty()) {
+            throw new IllegalArgumentException("RÃ¨gle " + source.getId() + " : Le groupe meme zone doit contenir au moins une regle");
+        }
+
+        Iterator<SimpleRuleWebDto> reglesIt = source.getRegles().iterator();
+        SimpleRuleWebDto firstRegle = reglesIt.next();
+        if (firstRegle.getBooleanOperator() != null) {
+            throw new IllegalArgumentException("RÃ¨gle " + firstRegle.getId() + " : La premiÃ¨re rÃ¨gle d'un groupe meme zone ne doit pas contenir d'opÃ©rateur");
+        }
+        checkRuleWebDtoIsAInstanseMemeZoneRules(firstRegle);
+        firstRegle.setZone(source.getZone());
+
+        GroupeMemeZone groupeMemeZone = new GroupeMemeZone(source.getId(), source.getZone(), source.isAffichageEtiquette(), mapper.map(firstRegle, SimpleRule.class));
+
+        int position = 0;
+        while (reglesIt.hasNext()) {
+            SimpleRuleWebDto otherRegle = reglesIt.next();
+            if (otherRegle.getBooleanOperator() == null) {
+                throw new IllegalArgumentException("RÃ¨gle " + otherRegle.getId() + " : Les rÃ¨gles suivantes d'un groupe meme zone doivent avoir un opÃ©rateur");
+            }
+            checkRuleWebDtoIsAInstanseMemeZoneRules(otherRegle);
+            otherRegle.setZone(source.getZone());
+            groupeMemeZone.addRegle(mapper.map(otherRegle, SimpleRule.class), getOperateur(otherRegle.getBooleanOperator()), position++);
+        }
+
+        return groupeMemeZone;
     }
 }

--- a/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
@@ -281,4 +281,41 @@ public class RuleControllerTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    @DisplayName("test creation regle complexe avec groupe meme zone imbrique")
+    void testIndexComplexRuleWithNestedSameZoneGroup() throws Exception {
+        String yaml =
+                "---\n" +
+                "rules:\n" +
+                "   - id: 9200\n" +
+                "     id-excel: 95555\n" +
+                "     message: test groupe meme zone\n" +
+                "     priorite: P1\n" +
+                "     regles:\n" +
+                "       - id: 9201\n" +
+                "         type: presencechainecaracteres\n" +
+                "         zone: '215'\n" +
+                "         souszone: 'a'\n" +
+                "         type-de-verification: CONTIENT\n" +
+                "         chaines-caracteres:\n" +
+                "           - chaine-caracteres: microfiche\n" +
+                "       - id: 9202\n" +
+                "         type: groupememezone\n" +
+                "         zone: '328'\n" +
+                "         operateur-booleen: ET\n" +
+                "         regles:\n" +
+                "           - id: 9203\n" +
+                "             type: positionsouszone\n" +
+                "             souszone: 'z'\n" +
+                "             positions:\n" +
+                "               - position: 1\n" +
+                "                 comparateur: DIFFERENT\n" +
+                "             operateur: OU\n";
+
+        this.mockMvc.perform(post("/api/v1/indexComplexRules")
+                        .contentType("application/x-yaml").characterEncoding(StandardCharsets.UTF_8)
+                        .content(yaml).characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk());
+    }
+
 }

--- a/web/src/test/java/fr/abes/qualimarc/web/mapper/WebDtoMapperTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/mapper/WebDtoMapperTest.java
@@ -1044,6 +1044,35 @@ public class WebDtoMapperTest {
         Assertions.assertEquals(complexRuleWebDto1.getRegles().size(),complexRule.getOtherRules().size() + 1);
     }
 
+    @Test
+    @DisplayName("test mapper groupe meme zone imbrique")
+    void converterComplexRuleWithSameZoneGroup() {
+        ComplexRuleWebDto complexRuleWebDto = new ComplexRuleWebDto();
+        complexRuleWebDto.setId(9200);
+        complexRuleWebDto.setMessage("message test");
+        complexRuleWebDto.setPriority("P1");
+
+        List<PresenceChaineCaracteresWebDto.ChaineCaracteresWebDto> chaines = new ArrayList<>();
+        chaines.add(new PresenceChaineCaracteresWebDto.ChaineCaracteresWebDto("microfiche"));
+        complexRuleWebDto.addRegle(new PresenceChaineCaracteresWebDto(9201, "215", null, "a", "CONTIENT", chaines));
+
+        PositionSousZoneWebDto.PositionsOperatorWebDto positionsOperatorWebDto = new PositionSousZoneWebDto.PositionsOperatorWebDto(1, ComparaisonOperateur.DIFFERENT);
+        List<fr.abes.qualimarc.web.dto.indexrules.SimpleRuleWebDto> reglesGroupe = new ArrayList<>();
+        reglesGroupe.add(new PositionSousZoneWebDto(9203, null, null, "z", Lists.newArrayList(positionsOperatorWebDto), BooleanOperateur.OU));
+        complexRuleWebDto.addRegle(new SameZoneRuleGroupWebDto(9202, "328", "ET", reglesGroupe));
+
+        ComplexRule complexRule = mapper.map(complexRuleWebDto, ComplexRule.class);
+
+        Assertions.assertEquals(1, complexRule.getOtherRules().size());
+        Assertions.assertTrue(complexRule.getOtherRules().get(0) instanceof LinkedRule);
+        LinkedRule linkedRule = (LinkedRule) complexRule.getOtherRules().get(0);
+        Assertions.assertTrue(linkedRule.getRule() instanceof GroupeMemeZone);
+        GroupeMemeZone groupeMemeZone = (GroupeMemeZone) linkedRule.getRule();
+        Assertions.assertEquals("328", groupeMemeZone.getZone());
+        Assertions.assertTrue(groupeMemeZone.getFirstRule() instanceof PositionSousZone);
+        Assertions.assertEquals("328", groupeMemeZone.getFirstRule().getZone());
+    }
+
     /**
      * Test du mapper converterResultAnalyseTest
      */


### PR DESCRIPTION
## Objet
- ajoute un type YAML `groupememezone` pour imbriquer un controle "meme zone" dans une regle complexe
- mappe ce nouveau bloc vers une regle composite cote core
- couvre le cas SOA-182 microfiche + controle sur la premiere sous-zone de 328

## Verification
- `mvn -pl core "-Dtest=ComplexRuleTest" test`
- `mvn -pl web "-Dtest=WebDtoMapperTest,RuleControllerTest" test`
