### PR TITLE
SOA-182 : traiter l'absence de sous-zone dans positionsouszone

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/PositionSousZone.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/PositionSousZone.java
@@ -131,7 +131,7 @@ public class PositionSousZone extends SimpleRule implements Serializable {
             }
 
             if (occurrences.isEmpty()) {
-                return false;
+                return matchesWhenSubfieldIsMissing(posOp.getComparaisonOperateur());
             }
 
             // Vérifie si au moins une occurrence valide la condition
@@ -149,6 +149,10 @@ public class PositionSousZone extends SimpleRule implements Serializable {
             case SUPERIEUR_EGAL: return index >= expectedIndex;
             default: return false;
         }
+    }
+
+    private boolean matchesWhenSubfieldIsMissing(ComparaisonOperateur comparaisonOperateur) {
+        return comparaisonOperateur == ComparaisonOperateur.DIFFERENT;
     }
 
     @Override

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/ComplexRuleTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/ComplexRuleTest.java
@@ -41,6 +41,9 @@ public class ComplexRuleTest {
     @Value("classpath:soa182-microfiche-valid-328.xml")
     private Resource xmlFileMicroficheValid328;
 
+    @Value("classpath:soa182-microfiche-missing-328z.xml")
+    private Resource xmlFileMicroficheMissing328z;
+
     @Test
     @DisplayName("test méthode isValid règle complexe avec une seule règle simple")
     void isValidWithOneRule() throws IOException {
@@ -641,6 +644,27 @@ public class ComplexRuleTest {
 
         Assertions.assertTrue(complexRule.isValid(invalidNotice));
         Assertions.assertFalse(complexRule.isValid(validNotice));
+    }
+
+    @Test
+    @DisplayName("test groupe meme zone combine 215 microfiche et controle 328 sans sous-zone z")
+    void testGroupeMemeZoneWithMicroficheRuleAndMissingZ() throws IOException {
+        JacksonXmlModule module = new JacksonXmlModule();
+        module.setDefaultUseWrapper(false);
+        XmlMapper mapper = new XmlMapper(module);
+
+        String xmlMissingZ = IOUtils.toString(new FileInputStream(xmlFileMicroficheMissing328z.getFile()), StandardCharsets.UTF_8);
+        NoticeXml missingZNotice = mapper.readValue(xmlMissingZ, NoticeXml.class);
+
+        TreeSet<ChaineCaracteres> chaines = new TreeSet<>();
+        chaines.add(new ChaineCaracteres(1, "microfiche", null));
+
+        ComplexRule complexRule = new ComplexRule(9300, "test", Priority.P1, new PresenceChaineCaracteres(9301, "215", false, "a", TypeVerification.CONTIENT, chaines));
+        PositionsOperator positionsOperator = new PositionsOperator(1, 1, ComparaisonOperateur.DIFFERENT);
+        GroupeMemeZone groupeMemeZone = new GroupeMemeZone(9302, "328", false, new PositionSousZone(9303, "328", false, "z", Lists.newArrayList(positionsOperator), BooleanOperateur.OU));
+        complexRule.addOtherRule(new LinkedRule(groupeMemeZone, BooleanOperateur.ET, 0, complexRule));
+
+        Assertions.assertTrue(complexRule.isValid(missingZNotice));
     }
 
         @Test

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/PositionSousZoneTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/PositionSousZoneTest.java
@@ -77,6 +77,21 @@ public class PositionSousZoneTest {
     }
 
     @Test
+    @DisplayName("positionsouszone different doit etre valide si la sous-zone est absente")
+    void isValidWhenSubfieldIsMissingAndComparatorIsDifferent() throws IOException {
+        String xml = IOUtils.toString(new FileInputStream(xmlFileNotice1.getFile()), StandardCharsets.UTF_8);
+        JacksonXmlModule module = new JacksonXmlModule();
+        module.setDefaultUseWrapper(false);
+        XmlMapper mapper = new XmlMapper(module);
+        NoticeXml notice = mapper.readValue(xml, NoticeXml.class);
+
+        PositionsOperator positionsOperatorDifferent = new PositionsOperator(1, 1, ComparaisonOperateur.DIFFERENT);
+        PositionSousZone rule = new PositionSousZone(1, "607", false, "v", Lists.newArrayList(positionsOperatorDifferent), BooleanOperateur.OU);
+
+        Assertions.assertTrue(rule.isValid(notice));
+    }
+
+    @Test
     @DisplayName("test getZones")
     void getZones() {
         PositionsOperator positionsOperator2 = new PositionsOperator(2, 2, ComparaisonOperateur.EGAL);

--- a/core/src/test/resources/soa182-microfiche-missing-328z.xml
+++ b/core/src/test/resources/soa182-microfiche-missing-328z.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+    <leader>00000nam0 2200000   450 </leader>
+    <controlfield tag="001">soa182-missing-z</controlfield>
+    <datafield tag="215" ind1=" " ind2=" ">
+        <subfield code="a">1 microfiche</subfield>
+        <subfield code="d">11 x 15 cm</subfield>
+    </datafield>
+    <datafield tag="328" ind1=" " ind2=" ">
+        <subfield code="b">These</subfield>
+        <subfield code="c">Informatique</subfield>
+    </datafield>
+</record>


### PR DESCRIPTION
## Resume
- aligne positionsouszone sur l'attendu metier quand la sous-zone cible est absente
- couvre le cas SOA-182 microfiche plus 328 sans sous-zone z
- ajoute les tests de non-regression associes

## Verification
- mvn -pl core -Dtest=PositionSousZoneTest,ComplexRuleTest test