### PR TITLE
SOA-183 : rendre statusApplication tolerante aux timeouts BaseXML

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/repository/basexml/NoticesBibioRepository.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/repository/basexml/NoticesBibioRepository.java
@@ -2,7 +2,9 @@ package fr.abes.qualimarc.core.repository.basexml;
 
 import fr.abes.qualimarc.core.configuration.BaseXMLConfiguration;
 import fr.abes.qualimarc.core.model.entity.basexml.NoticesBibio;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
 
 import java.util.Calendar;
@@ -13,5 +15,6 @@ import java.util.Optional;
 public interface NoticesBibioRepository extends JpaRepository<NoticesBibio, Integer> {
     Optional<NoticesBibio> getByPpn(String ppn);
 
+    @QueryHints(@QueryHint(name = "jakarta.persistence.query.timeout", value = "2000"))
     NoticesBibio findFirstByDateEtatBeforeOrderByDateEtatDesc(Calendar date);
 }

--- a/core/src/main/java/fr/abes/qualimarc/core/service/StatutsService.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/service/StatutsService.java
@@ -14,6 +14,8 @@ import java.util.GregorianCalendar;
 @Service
 @Slf4j
 public class StatutsService {
+    private static final String LAST_PPN_SYNC_FALLBACK = "Impossible de recuperer le dernier PPN connu";
+
     @Autowired
     private NoticesBibioRepository noticeRepository;
 
@@ -29,7 +31,7 @@ public class StatutsService {
         try {
             String objectTest = baseXmlJdbcTemplate.queryForObject("SELECT SYSDATE FROM DUAL", String.class);
             return objectTest != null;
-        } catch (DataAccessException e){
+        } catch (DataAccessException e) {
             log.info(e.getMessage());
             return false;
         }
@@ -39,7 +41,7 @@ public class StatutsService {
         try {
             String objectTest = qualimarcJdbcTemplate.queryForObject("SELECT 1", String.class);
             return objectTest != null;
-        } catch (DataAccessException e){
+        } catch (DataAccessException e) {
             log.info(e.getMessage());
             return false;
         }
@@ -48,9 +50,15 @@ public class StatutsService {
     public String getDateLastPpnSynchronised() {
         SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
         try {
-            return format.format(noticeRepository.findFirstByDateEtatBeforeOrderByDateEtatDesc(new GregorianCalendar()).getDateEtat().getTime());
+            return format.format(
+                    noticeRepository
+                            .findFirstByDateEtatBeforeOrderByDateEtatDesc(new GregorianCalendar())
+                            .getDateEtat()
+                            .getTime()
+            );
         } catch (Exception ex) {
-            return "Impossible de récupérer le dernier PPN connnu";
+            log.warn("Impossible de recuperer le dernier PPN synchronise depuis BaseXML", ex);
+            return LAST_PPN_SYNC_FALLBACK;
         }
     }
 }

--- a/core/src/test/java/fr/abes/qualimarc/core/service/StatutServiceTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/service/StatutServiceTest.java
@@ -72,6 +72,6 @@ public class StatutServiceTest {
     @Test
     void testGetDateLastPpnSynchronisedError() {
         Mockito.doThrow(CannotGetJdbcConnectionException.class).when(noticeRepository).findFirstByDateEtatBeforeOrderByDateEtatDesc(Mockito.any());
-        Assertions.assertEquals("Impossible de récupérer le dernier PPN connnu", service.getDateLastPpnSynchronised());
+        Assertions.assertEquals("Impossible de recuperer le dernier PPN connu", service.getDateLastPpnSynchronised());
     }
 }


### PR DESCRIPTION
## Resume
- ajoute un timeout JPA sur la requete de recuperation du dernier PPN synchronise
- fait retomber `statusApplication` sur un message de secours au lieu de bloquer l'endpoint
- aligne le test de service sur le nouveau message de repli

## Verification
- `mvn -pl core -Dtest=StatutServiceTest test`
- `mvn -pl web -Dtest=StatutsControllerTest test`