### PR TITLE
SOA-183 : promouvoir develop vers main

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/repository/basexml/NoticesBibioRepository.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/repository/basexml/NoticesBibioRepository.java
@@ -2,7 +2,9 @@ package fr.abes.qualimarc.core.repository.basexml;
 
 import fr.abes.qualimarc.core.configuration.BaseXMLConfiguration;
 import fr.abes.qualimarc.core.model.entity.basexml.NoticesBibio;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
 
 import java.util.Calendar;
@@ -13,5 +15,6 @@ import java.util.Optional;
 public interface NoticesBibioRepository extends JpaRepository<NoticesBibio, Integer> {
     Optional<NoticesBibio> getByPpn(String ppn);
 
+    @QueryHints(@QueryHint(name = "jakarta.persistence.query.timeout", value = "2000"))
     NoticesBibio findFirstByDateEtatBeforeOrderByDateEtatDesc(Calendar date);
 }

--- a/core/src/main/java/fr/abes/qualimarc/core/repository/basexml/NoticesBibioRepository.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/repository/basexml/NoticesBibioRepository.java
@@ -2,12 +2,11 @@ package fr.abes.qualimarc.core.repository.basexml;
 
 import fr.abes.qualimarc.core.configuration.BaseXMLConfiguration;
 import fr.abes.qualimarc.core.model.entity.basexml.NoticesBibio;
-import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.Calendar;
+import java.util.Date;
 import java.util.Optional;
 
 @BaseXMLConfiguration
@@ -15,6 +14,18 @@ import java.util.Optional;
 public interface NoticesBibioRepository extends JpaRepository<NoticesBibio, Integer> {
     Optional<NoticesBibio> getByPpn(String ppn);
 
-    @QueryHints(@QueryHint(name = "jakarta.persistence.query.timeout", value = "2000"))
-    NoticesBibio findFirstByDateEtatBeforeOrderByDateEtatDesc(Calendar date);
+    @Query(
+            value = """
+                    SELECT DATE_ETAT
+                    FROM (
+                        SELECT /*+ INDEX_DESC(NB INDEX_DATE_ETAT_BIBIO) */ NB.DATE_ETAT
+                        FROM AUTORITES.NOTICESBIBIO NB
+                        WHERE NB.DATE_ETAT < SYSDATE
+                        ORDER BY NB.DATE_ETAT DESC
+                    )
+                    WHERE ROWNUM = 1
+                    """,
+            nativeQuery = true
+    )
+    Date findLatestDateEtat();
 }

--- a/core/src/main/java/fr/abes/qualimarc/core/service/StatutsService.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/service/StatutsService.java
@@ -14,6 +14,8 @@ import java.util.GregorianCalendar;
 @Service
 @Slf4j
 public class StatutsService {
+    private static final String LAST_PPN_SYNC_FALLBACK = "Impossible de recuperer le dernier PPN connu";
+
     @Autowired
     private NoticesBibioRepository noticeRepository;
 
@@ -29,7 +31,7 @@ public class StatutsService {
         try {
             String objectTest = baseXmlJdbcTemplate.queryForObject("SELECT SYSDATE FROM DUAL", String.class);
             return objectTest != null;
-        } catch (DataAccessException e){
+        } catch (DataAccessException e) {
             log.info(e.getMessage());
             return false;
         }
@@ -39,7 +41,7 @@ public class StatutsService {
         try {
             String objectTest = qualimarcJdbcTemplate.queryForObject("SELECT 1", String.class);
             return objectTest != null;
-        } catch (DataAccessException e){
+        } catch (DataAccessException e) {
             log.info(e.getMessage());
             return false;
         }
@@ -48,9 +50,15 @@ public class StatutsService {
     public String getDateLastPpnSynchronised() {
         SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
         try {
-            return format.format(noticeRepository.findFirstByDateEtatBeforeOrderByDateEtatDesc(new GregorianCalendar()).getDateEtat().getTime());
+            return format.format(
+                    noticeRepository
+                            .findFirstByDateEtatBeforeOrderByDateEtatDesc(new GregorianCalendar())
+                            .getDateEtat()
+                            .getTime()
+            );
         } catch (Exception ex) {
-            return "Impossible de récupérer le dernier PPN connnu";
+            log.warn("Impossible de recuperer le dernier PPN synchronise depuis BaseXML", ex);
+            return LAST_PPN_SYNC_FALLBACK;
         }
     }
 }

--- a/core/src/main/java/fr/abes/qualimarc/core/service/StatutsService.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/service/StatutsService.java
@@ -9,7 +9,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 import java.text.SimpleDateFormat;
-import java.util.GregorianCalendar;
+import java.util.Date;
 
 @Service
 @Slf4j
@@ -50,12 +50,11 @@ public class StatutsService {
     public String getDateLastPpnSynchronised() {
         SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
         try {
-            return format.format(
-                    noticeRepository
-                            .findFirstByDateEtatBeforeOrderByDateEtatDesc(new GregorianCalendar())
-                            .getDateEtat()
-                            .getTime()
-            );
+            Date lastSyncDate = noticeRepository.findLatestDateEtat();
+            if (lastSyncDate == null) {
+                return LAST_PPN_SYNC_FALLBACK;
+            }
+            return format.format(lastSyncDate);
         } catch (Exception ex) {
             log.warn("Impossible de recuperer le dernier PPN synchronise depuis BaseXML", ex);
             return LAST_PPN_SYNC_FALLBACK;

--- a/core/src/test/java/fr/abes/qualimarc/core/service/StatutServiceTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/service/StatutServiceTest.java
@@ -72,6 +72,6 @@ public class StatutServiceTest {
     @Test
     void testGetDateLastPpnSynchronisedError() {
         Mockito.doThrow(CannotGetJdbcConnectionException.class).when(noticeRepository).findFirstByDateEtatBeforeOrderByDateEtatDesc(Mockito.any());
-        Assertions.assertEquals("Impossible de récupérer le dernier PPN connnu", service.getDateLastPpnSynchronised());
+        Assertions.assertEquals("Impossible de recuperer le dernier PPN connu", service.getDateLastPpnSynchronised());
     }
 }

--- a/core/src/test/java/fr/abes/qualimarc/core/service/StatutServiceTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/service/StatutServiceTest.java
@@ -1,6 +1,5 @@
 package fr.abes.qualimarc.core.service;
 
-import fr.abes.qualimarc.core.model.entity.basexml.NoticesBibio;
 import fr.abes.qualimarc.core.repository.basexml.NoticesBibioRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -16,6 +15,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {StatutsService.class})
@@ -62,16 +62,15 @@ public class StatutServiceTest {
     void testGetDateLastPpnSynchronised() {
         SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
         Calendar now = Calendar.getInstance();
-        NoticesBibio notice = new NoticesBibio();
-        notice.setDateEtat(now);
-        Mockito.when(noticeRepository.findFirstByDateEtatBeforeOrderByDateEtatDesc(Mockito.any())).thenReturn(notice);
+        Date lastSyncDate = now.getTime();
+        Mockito.when(noticeRepository.findLatestDateEtat()).thenReturn(lastSyncDate);
 
-        Assertions.assertEquals(format.format(now.getTime()), service.getDateLastPpnSynchronised());
+        Assertions.assertEquals(format.format(lastSyncDate), service.getDateLastPpnSynchronised());
     }
 
     @Test
     void testGetDateLastPpnSynchronisedError() {
-        Mockito.doThrow(CannotGetJdbcConnectionException.class).when(noticeRepository).findFirstByDateEtatBeforeOrderByDateEtatDesc(Mockito.any());
+        Mockito.doThrow(CannotGetJdbcConnectionException.class).when(noticeRepository).findLatestDateEtat();
         Assertions.assertEquals("Impossible de recuperer le dernier PPN connu", service.getDateLastPpnSynchronised());
     }
 }


### PR DESCRIPTION
## Resume
- promeut le correctif SOA-183 deja valide sur develop vers main
- inclut le fallback de `statusApplication` en cas d'echec BaseXML
- inclut l'optimisation Oracle de recuperation de la derniere date de synchronisation

## Verification
- `mvn -pl core -Dtest=StatutServiceTest test`
- `mvn -pl web -Dtest=StatutsControllerTest test`
- verification fonctionnelle sur `https://qualimarc-dev.sudoc.fr/api/v1/statusApplication`