### PR TITLE
Livraison main depuis develop : SOA-183 et SOA-179

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/PresenceSousZonesMemeZone.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/PresenceSousZonesMemeZone.java
@@ -78,6 +78,9 @@ public class PresenceSousZonesMemeZone extends SimpleRule implements Serializabl
     public List<String> getZones() {
         List<String> listZone = new ArrayList<>();
         for (int i =0; i < sousZoneOperators.size(); i++) {
+            if (!sousZoneOperators.get(i).isAffichageEtiquette()) {
+                continue;
+            }
             StringBuilder zone = new StringBuilder();
             zone.append(this.zone);
             zone.append("$");

--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/souszoneoperator/SousZoneOperator.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/structure/souszoneoperator/SousZoneOperator.java
@@ -29,6 +29,9 @@ public class SousZoneOperator implements Serializable {
     @NotNull
     private boolean isPresent;
 
+    @Column(name = "AFFICHAGE_ETIQUETTE")
+    private Boolean affichageEtiquette;
+
     @Column(name="OPERATEUR")
     private BooleanOperateur operateur;
 
@@ -36,15 +39,30 @@ public class SousZoneOperator implements Serializable {
     @JoinColumn(name = "ID_PRESENCE_SOUS_ZONE_MEME_ZONE")
     private PresenceSousZonesMemeZone presenceSousZonesMemeZone;
 
-    public SousZoneOperator(String sousZone, boolean isPresent, BooleanOperateur operateur, PresenceSousZonesMemeZone presenceSousZonesMemeZone) {
+    public SousZoneOperator(String sousZone, boolean isPresent, Boolean affichageEtiquette, BooleanOperateur operateur, PresenceSousZonesMemeZone presenceSousZonesMemeZone) {
         this.sousZone = sousZone;
         this.isPresent = isPresent;
+        this.affichageEtiquette = affichageEtiquette;
         this.operateur = operateur;
         this.presenceSousZonesMemeZone = presenceSousZonesMemeZone;
     }
-    public SousZoneOperator(String sousZone, boolean isPresent, PresenceSousZonesMemeZone presenceSousZonesMemeZone) {
+
+    public SousZoneOperator(String sousZone, boolean isPresent, BooleanOperateur operateur, PresenceSousZonesMemeZone presenceSousZonesMemeZone) {
+        this(sousZone, isPresent, true, operateur, presenceSousZonesMemeZone);
+    }
+
+    public SousZoneOperator(String sousZone, boolean isPresent, Boolean affichageEtiquette, PresenceSousZonesMemeZone presenceSousZonesMemeZone) {
         this.sousZone = sousZone;
         this.isPresent = isPresent;
+        this.affichageEtiquette = affichageEtiquette;
         this.presenceSousZonesMemeZone = presenceSousZonesMemeZone;
+    }
+
+    public SousZoneOperator(String sousZone, boolean isPresent, PresenceSousZonesMemeZone presenceSousZonesMemeZone) {
+        this(sousZone, isPresent, true, presenceSousZonesMemeZone);
+    }
+
+    public boolean isAffichageEtiquette() {
+        return this.affichageEtiquette == null || this.affichageEtiquette;
     }
 }

--- a/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/structure/PresenceSousZonesMemeZoneWebDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/indexrules/structure/PresenceSousZonesMemeZoneWebDto.java
@@ -47,6 +47,7 @@ public class PresenceSousZonesMemeZoneWebDto extends SimpleRuleWebDto {
     }
 
     @Getter
+    @Setter
     @NoArgsConstructor
     public static class SousZoneOperatorWebDto {
 
@@ -59,6 +60,9 @@ public class PresenceSousZonesMemeZoneWebDto extends SimpleRuleWebDto {
         @JsonProperty("presence")
         private boolean isPresent;
 
+        @JsonProperty(value = "affichage-etiquette", defaultValue = "true")
+        private boolean affichageEtiquette = true;
+
         @JsonProperty("operateur-booleen")
         private BooleanOperateur operator;
 
@@ -66,13 +70,23 @@ public class PresenceSousZonesMemeZoneWebDto extends SimpleRuleWebDto {
          * Constructeur utilisé pour le premier souszoneoperateur
          */
         public SousZoneOperatorWebDto(String sousZone, boolean isPresent) {
+            this(sousZone, isPresent, true);
+        }
+
+        public SousZoneOperatorWebDto(String sousZone, boolean isPresent, boolean affichageEtiquette) {
             this.sousZone = sousZone;
             this.isPresent = isPresent;
+            this.affichageEtiquette = affichageEtiquette;
         }
 
         public SousZoneOperatorWebDto(String sousZone, boolean isPresent, BooleanOperateur operator) {
+            this(sousZone, isPresent, operator, true);
+        }
+
+        public SousZoneOperatorWebDto(String sousZone, boolean isPresent, BooleanOperateur operator, boolean affichageEtiquette) {
             this.sousZone = sousZone;
             this.isPresent = isPresent;
+            this.affichageEtiquette = affichageEtiquette;
             this.operator = operator;
         }
     }

--- a/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/mapper/WebDtoMapper.java
@@ -804,11 +804,11 @@ public class WebDtoMapper {
             Iterator<PresenceSousZonesMemeZoneWebDto.SousZoneOperatorWebDto> sousZoneOperatorIt = source.getSousZones().listIterator();
             PresenceSousZonesMemeZoneWebDto.SousZoneOperatorWebDto firstSousZone = sousZoneOperatorIt.next();
             if (null == firstSousZone.getOperator()) {
-                target.addSousZoneOperator(new SousZoneOperator(firstSousZone.getSousZone(), firstSousZone.isPresent(), target));
+                target.addSousZoneOperator(new SousZoneOperator(firstSousZone.getSousZone(), firstSousZone.isPresent(), firstSousZone.isAffichageEtiquette(), target));
                 while (sousZoneOperatorIt.hasNext()) {
                     PresenceSousZonesMemeZoneWebDto.SousZoneOperatorWebDto nextSousZone = sousZoneOperatorIt.next();
                     if (null != nextSousZone.getOperator()) {
-                        target.addSousZoneOperator(new SousZoneOperator(nextSousZone.getSousZone(), nextSousZone.isPresent(), nextSousZone.getOperator(), target));
+                        target.addSousZoneOperator(new SousZoneOperator(nextSousZone.getSousZone(), nextSousZone.isPresent(), nextSousZone.isAffichageEtiquette(), nextSousZone.getOperator(), target));
                     } else {
                         throw new IllegalArgumentException("Règle " + source.getId() + " : Les sous-zones en dehors de la première doivent avoir un opérateur booléen");
                     }

--- a/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
@@ -250,6 +250,31 @@ public class RuleControllerTest {
     }
 
     @Test
+    @DisplayName("test creation regle complexe presencesouszonesmemezone avec affichage-etiquette sur une sous-zone")
+    void testIndexComplexRulePresenceSousZonesMemeZoneWithSousZoneAffichageEtiquette() throws Exception {
+        String yaml =
+                "rules:\n" +
+                "   - id: 605\n" +
+                "     id-excel: 433\n" +
+                "     type: presencesouszonesmemezone\n" +
+                "     message: test 6XX sous-zone cachee\n" +
+                "     zone: '6XX'\n" +
+                "     priorite: P1\n" +
+                "     souszones:\n" +
+                "       - souszone: '2'\n" +
+                "         presence: false\n" +
+                "       - souszone: 'a'\n" +
+                "         presence: true\n" +
+                "         affichage-etiquette: false\n" +
+                "         operateur-booleen: ET\n";
+
+        this.mockMvc.perform(post("/api/v1/indexRules")
+                .contentType("application/x-yaml").characterEncoding(StandardCharsets.UTF_8)
+                .content(yaml).characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     @DisplayName("test creation regle complexe avec dependance et position negative")
     void testIndexComplexRuleDependencyWithNegativePosition() throws Exception {
         String yaml =

--- a/web/src/test/java/fr/abes/qualimarc/web/mapper/WebDtoMapperTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/mapper/WebDtoMapperTest.java
@@ -384,9 +384,9 @@ public class WebDtoMapperTest {
         Integer ruleSetWebDto = 1;
         ruleSetsList.add(ruleSetWebDto);
 
-        PresenceSousZonesMemeZoneWebDto rule5 = new PresenceSousZonesMemeZoneWebDto(1, 1, ruleSetsList, "test", false, "200", "P1", typeDoc, typeThese, new LinkedList<>());
-        rule5.addSousZone(new PresenceSousZonesMemeZoneWebDto.SousZoneOperatorWebDto("a", true));
-        rule5.addSousZone(new PresenceSousZonesMemeZoneWebDto.SousZoneOperatorWebDto("b", false, BooleanOperateur.ET));
+        PresenceSousZonesMemeZoneWebDto rule5 = new PresenceSousZonesMemeZoneWebDto(1, 1, ruleSetsList, "test", true, "200", "P1", typeDoc, typeThese, new LinkedList<>());
+        rule5.addSousZone(new PresenceSousZonesMemeZoneWebDto.SousZoneOperatorWebDto("a", true, false));
+        rule5.addSousZone(new PresenceSousZonesMemeZoneWebDto.SousZoneOperatorWebDto("b", false, BooleanOperateur.ET, true));
 
         ComplexRule complexRule = mapper.map(rule5, ComplexRule.class);
 
@@ -396,12 +396,16 @@ public class WebDtoMapperTest {
         Assertions.assertEquals(rule5.getPriority(), complexRule.getPriority().toString());
         PresenceSousZonesMemeZone firstRule = (PresenceSousZonesMemeZone) complexRule.getFirstRule();
         Assertions.assertEquals(rule5.getZone(), firstRule.getZone());
+        Assertions.assertEquals(1, complexRule.getZonesFromChildren().size());
+        Assertions.assertEquals("200$b", complexRule.getZonesFromChildren().get(0));
         Assertions.assertEquals(2, firstRule.getSousZoneOperators().size());
         Assertions.assertEquals("a", firstRule.getSousZoneOperators().get(0).getSousZone());
         Assertions.assertTrue(firstRule.getSousZoneOperators().get(0).isPresent());
+        Assertions.assertFalse(firstRule.getSousZoneOperators().get(0).isAffichageEtiquette());
         Assertions.assertEquals("b", firstRule.getSousZoneOperators().get(1).getSousZone());
         Assertions.assertEquals(BooleanOperateur.ET, firstRule.getSousZoneOperators().get(1).getOperateur());
         Assertions.assertFalse(firstRule.getSousZoneOperators().get(1).isPresent());
+        Assertions.assertTrue(firstRule.getSousZoneOperators().get(1).isAffichageEtiquette());
         Assertions.assertEquals(rule5.getTypesDoc().size(), complexRule.getFamillesDocuments().size());
         Assertions.assertTrue(complexRule.getFamillesDocuments().stream().findFirst().isPresent());
         Assertions.assertEquals(rule5.getTypesDoc().get(0), complexRule.getFamillesDocuments().stream().findFirst().get().getId());


### PR DESCRIPTION
## Résumé
- promeut dans `main` les correctifs déjà validés sur `develop`
- inclut l’optimisation de `statusApplication` pour SOA-183
- inclut le correctif SOA-179 sur `affichage-etiquette` dans `presencesouszonesmemezone`

## Vérifications
- tests Maven passés sur les modules `core` et `web`
- image `develop-api` déjà publiée et validée sur l’environnement de dev
- validation fonctionnelle du parsing YAML SOA-179 en dev