### PR TITLE
Synchronise develop vers main pour le token API

### DIFF
--- a/docs/superpowers/plans/2026-07-02-harmonisation-token-api.md
+++ b/docs/superpowers/plans/2026-07-02-harmonisation-token-api.md
@@ -1,0 +1,289 @@
+# Harmonisation du token API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** supprimer la generation et l'affichage du token d'administration au demarrage, puis faire reposer l'authentification sur un token configure identique entre environnements.
+
+**Architecture:** le code de bootstrap Spring ne cree plus de JWT local. Le fournisseur de securite lit un token admin configure (`jwt.token`) et authentifie uniquement les requetes portant exactement ce bearer token. Les profils `dev`, `test` et `prod` exposent la meme cle de configuration sans embarquer la valeur secrete dans le depot.
+
+**Tech Stack:** Java 21, Spring Boot 3, Spring Security, JUnit 5, Mockito
+
+---
+
+### Task 1: Cadrer le nouveau contrat du fournisseur de token
+
+**Files:**
+- Create: `web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java`
+- Modify: `web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java`
+- Test: `web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package fr.abes.qualimarc.web.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider createProvider() {
+        JwtTokenProvider provider = new JwtTokenProvider();
+        ReflectionTestUtils.setField(provider, "configuredToken", "token-admin-qualimarc");
+        ReflectionTestUtils.setField(provider, "anonymousUser", "qualimarcUser");
+        return provider;
+    }
+
+    @Test
+    void validateTokenReturnsTrueForConfiguredToken() {
+        JwtTokenProvider provider = createProvider();
+
+        assertThat(provider.validateToken("token-admin-qualimarc")).isTrue();
+    }
+
+    @Test
+    void validateTokenReturnsFalseForDifferentToken() {
+        JwtTokenProvider provider = createProvider();
+
+        assertThat(provider.validateToken("token-invalide")).isFalse();
+    }
+
+    @Test
+    void getJwtFromRequestExtractsBearerToken() {
+        JwtTokenProvider provider = createProvider();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer token-admin-qualimarc");
+
+        assertThat(provider.getJwtFromRequest(request)).isEqualTo("token-admin-qualimarc");
+    }
+
+    @Test
+    void getUsernameFromJwtTokenReturnsConfiguredAnonymousUser() {
+        JwtTokenProvider provider = createProvider();
+
+        assertThat(provider.getUsernameFromJwtToken("token-admin-qualimarc")).isEqualTo("qualimarcUser");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -pl web -Dtest=JwtTokenProviderTest test`
+Expected: FAIL because `configuredToken` does not exist yet and `validateToken` still expects a signed JWT.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```java
+package fr.abes.qualimarc.web.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.token:}")
+    private String configuredToken;
+
+    @Value("${jwt.anonymousUser}")
+    private String anonymousUser;
+
+    public boolean validateToken(String authToken) {
+        if (!StringUtils.hasText(configuredToken) || !StringUtils.hasText(authToken)) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                configuredToken.getBytes(StandardCharsets.UTF_8),
+                authToken.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    public String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public String getUsernameFromJwtToken(String token) {
+        if (!validateToken(token)) {
+            throw new IllegalArgumentException("Token API invalide");
+        }
+        return anonymousUser;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -pl web -Dtest=JwtTokenProviderTest test`
+Expected: PASS with 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
+git commit -m "test: verrouiller le fournisseur du token API"
+```
+
+### Task 2: Retirer la generation du token au demarrage
+
+**Files:**
+- Create: `web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java`
+- Modify: `web/src/main/java/fr/abes/qualimarc/QualimarcAPIApplication.java`
+- Test: `web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package fr.abes.qualimarc;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.CommandLineRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QualimarcAPIApplicationTest {
+
+    @Test
+    void applicationDoesNotImplementCommandLineRunnerAnymore() {
+        assertThat(CommandLineRunner.class.isAssignableFrom(QualimarcAPIApplication.class)).isFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -pl web -Dtest=QualimarcAPIApplicationTest test`
+Expected: FAIL because `QualimarcAPIApplication` currently implements `CommandLineRunner`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```java
+package fr.abes.qualimarc;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.TimeZone;
+
+@SpringBootApplication
+public class QualimarcAPIApplication {
+
+    public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Paris"));
+        SpringApplication.run(QualimarcAPIApplication.class, args);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -pl web -Dtest=QualimarcAPIApplicationTest test`
+Expected: PASS with 1 test green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/main/java/fr/abes/qualimarc/QualimarcAPIApplication.java web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java
+git commit -m "fix: supprimer la generation du token au demarrage"
+```
+
+### Task 3: Harmoniser la configuration des profils
+
+**Files:**
+- Modify: `web/src/main/resources/application-dev.properties`
+- Modify: `web/src/main/resources/application-test.properties`
+- Modify: `web/src/main/resources/application-prod.properties`
+- Test: `web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java`
+
+- [ ] **Step 1: Write the failing configuration expectation in the existing test**
+
+Add this test to `web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java`:
+
+```java
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Test
+void profilePropertyFilesExposeTheSameJwtKeys() throws Exception {
+    String expectedAnonymousUserLine = "jwt.anonymousUser=qualimarcUser";
+    String expectedTokenLine = "jwt.token=${JWT_TOKEN:}";
+
+    assertThat(Files.readString(Path.of("src/main/resources/application-dev.properties"))).contains(expectedAnonymousUserLine, expectedTokenLine);
+    assertThat(Files.readString(Path.of("src/main/resources/application-test.properties"))).contains(expectedAnonymousUserLine, expectedTokenLine);
+    assertThat(Files.readString(Path.of("src/main/resources/application-prod.properties"))).contains(expectedAnonymousUserLine, expectedTokenLine);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -pl web -Dtest=JwtTokenProviderTest test`
+Expected: FAIL because the profile files still declare `jwt.secret` and do not expose `jwt.token`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In each profile file, replace the JWT section with:
+
+```properties
+jwt.anonymousUser=qualimarcUser
+jwt.token=${JWT_TOKEN:}
+```
+
+Apply the replacement in:
+
+```properties
+web/src/main/resources/application-dev.properties
+web/src/main/resources/application-test.properties
+web/src/main/resources/application-prod.properties
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -pl web -Dtest=JwtTokenProviderTest test`
+Expected: PASS with 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/main/resources/application-dev.properties web/src/main/resources/application-test.properties web/src/main/resources/application-prod.properties web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
+git commit -m "fix: harmoniser la configuration du token API"
+```
+
+### Task 4: Verification finale du module web
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-02-harmonisation-token-api.md`
+- Test: `web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java`
+- Test: `web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java`
+
+- [ ] **Step 1: Run the focused test suite**
+
+Run: `mvn -pl web -Dtest=QualimarcAPIApplicationTest,JwtTokenProviderTest test`
+Expected: PASS with the bootstrap and token tests green.
+
+- [ ] **Step 2: Run the module test suite**
+
+Run: `mvn -pl web test`
+Expected: PASS for the `web` module with no regression on controllers and mappers.
+
+- [ ] **Step 3: Inspect git state**
+
+Run: `git status --short`
+Expected: no modified tracked files except this plan if you decide to tick boxes manually.
+
+- [ ] **Step 4: Commit the completed implementation**
+
+```bash
+git add web/src/main/java/fr/abes/qualimarc/QualimarcAPIApplication.java web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java web/src/main/resources/application-dev.properties web/src/main/resources/application-test.properties web/src/main/resources/application-prod.properties web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
+git commit -m "fix: supprimer le token genere au demarrage"
+```

--- a/docs/superpowers/specs/2026-07-02-harmonisation-token-api-design.md
+++ b/docs/superpowers/specs/2026-07-02-harmonisation-token-api-design.md
@@ -1,0 +1,65 @@
+# Design - Harmonisation du token API
+
+## Contexte
+
+L'API Qualimarc protege certains endpoints d'administration avec un JWT partage entre environnements. Le code actuel genere aussi un token au demarrage de l'application et l'affiche sur la sortie standard. Ce comportement cree un risque de fuite du secret d'exploitation et rend le fonctionnement dependant d'un token calcule localement plutot que du token configure.
+
+En parallele, le job Ansible de production attend un token precis. L'objectif immediat est donc de corriger le point de securite critique sans casser l'exploitation existante.
+
+## Objectif
+
+Corriger en priorite le point 1 du rapport en faisant reposer l'authentification uniquement sur un token configure, non genere au boot, et harmoniser la valeur attendue entre `dev`, `test` et `prod`.
+
+## Perimetre
+
+- `web/src/main/java/fr/abes/qualimarc/QualimarcAPIApplication.java`
+- `web/src/main/java/fr/abes/qualimarc/web/security/*`
+- `web/src/main/resources/application-dev.properties`
+- `web/src/main/resources/application-test.properties`
+- `web/src/main/resources/application-prod.properties`
+- tests `web/src/test`
+
+Hors perimetre pour cette etape:
+
+- refonte complete du mecanisme d'authentification admin
+- rotation de secret ou externalisation vers un coffre-fort
+- correction des autres points du rapport
+
+## Approche retenue
+
+### 1. Supprimer la generation du token au demarrage
+
+L'application ne doit plus generer de JWT au boot et ne doit plus l'afficher sur la sortie standard. Le contexte de securite initialise localement au demarrage sera retire.
+
+### 2. Conserver la validation JWT cote filtre
+
+Le filtre HTTP continue de valider les JWT recus via le header `Authorization: Bearer ...`, mais uniquement a partir du secret configure par environnement.
+
+### 3. Harmoniser la configuration des environnements
+
+Les fichiers `application-dev.properties`, `application-test.properties` et `application-prod.properties` seront alignes sur la meme valeur de `jwt.anonymousUser` et de `jwt.secret`, en coherence avec le token de production transmis pour Ansible.
+
+Important: la valeur du secret configure doit etre compatible avec le token deja utilise en production. Le but de cette etape est la compatibilite d'exploitation, pas l'amelioration finale du modele de secret.
+
+## Impacts attendus
+
+- plus aucun token ne sera imprime au demarrage
+- les jobs et appels existants continueront a fonctionner s'ils utilisent le token partage attendu
+- le comportement sera stable entre `dev`, `test` et `prod`
+
+## Tests prevus
+
+- test unitaire ou d'integration verifiant qu'aucune generation de token au demarrage n'est necessaire
+- test sur `JwtTokenProvider` ou `JwtAuthenticationFilter` validant qu'un token connu reste accepte avec la configuration harmonisee
+- execution de `mvn test` au minimum sur le module `web`, idealement sur l'ensemble du projet si le temps de cycle reste acceptable
+
+## Risques et garde-fous
+
+- risque: mauvais couple `jwt.anonymousUser` / `jwt.secret` et rupture des appels Ansible
+  garde-fou: ajouter un test avec le token partage fourni
+- risque: dependance implicite a l'initialisation du `SecurityContextHolder` au boot
+  garde-fou: supprimer le code de boot puis verifier les tests web
+
+## Resultat attendu
+
+Une branche dediee porte un correctif minimal et exploitable qui ferme la fuite la plus critique du rapport tout en alignant `dev`, `test` et `prod` sur le meme token d'administration.

--- a/docs/superpowers/specs/2026-07-02-harmonisation-token-api-design.md
+++ b/docs/superpowers/specs/2026-07-02-harmonisation-token-api-design.md
@@ -31,15 +31,15 @@ Hors perimetre pour cette etape:
 
 L'application ne doit plus generer de JWT au boot et ne doit plus l'afficher sur la sortie standard. Le contexte de securite initialise localement au demarrage sera retire.
 
-### 2. Conserver la validation JWT cote filtre
+### 2. Conserver la validation du token cote filtre
 
-Le filtre HTTP continue de valider les JWT recus via le header `Authorization: Bearer ...`, mais uniquement a partir du secret configure par environnement.
+Le filtre HTTP continue de valider le bearer token recu via le header `Authorization: Bearer ...`, mais en le comparant directement a la valeur configuree par environnement plutot qu'en recalculant une signature JWT.
 
 ### 3. Harmoniser la configuration des environnements
 
-Les fichiers `application-dev.properties`, `application-test.properties` et `application-prod.properties` seront alignes sur la meme valeur de `jwt.anonymousUser` et de `jwt.secret`, en coherence avec le token de production transmis pour Ansible.
+Les fichiers `application-dev.properties`, `application-test.properties` et `application-prod.properties` seront alignes sur le meme contrat `jwt.anonymousUser` et `jwt.token`, avec une injection par variable d'environnement `JWT_TOKEN` pour eviter de versionner le secret dans le depot.
 
-Important: la valeur du secret configure doit etre compatible avec le token deja utilise en production. Le but de cette etape est la compatibilite d'exploitation, pas l'amelioration finale du modele de secret.
+Important: la valeur operationnelle du token reste celle deja utilisee en production pour Ansible. Le but de cette etape est la compatibilite d'exploitation sans exposition du secret dans Git.
 
 ## Impacts attendus
 
@@ -55,7 +55,7 @@ Important: la valeur du secret configure doit etre compatible avec le token deja
 
 ## Risques et garde-fous
 
-- risque: mauvais couple `jwt.anonymousUser` / `jwt.secret` et rupture des appels Ansible
+- risque: mauvais couple `jwt.anonymousUser` / `jwt.token` et rupture des appels Ansible
   garde-fou: ajouter un test avec le token partage fourni
 - risque: dependance implicite a l'initialisation du `SecurityContextHolder` au boot
   garde-fou: supprimer le code de boot puis verifier les tests web

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -45,24 +45,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-api</artifactId>
-            <version>0.13.0</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-impl</artifactId>
-            <version>0.13.0</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
-            <version>0.13.0</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/web/src/main/java/fr/abes/qualimarc/QualimarcAPIApplication.java
+++ b/web/src/main/java/fr/abes/qualimarc/QualimarcAPIApplication.java
@@ -1,50 +1,15 @@
 package fr.abes.qualimarc;
 
-
-import fr.abes.qualimarc.web.security.JwtTokenProvider;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.core.env.Environment;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.TimeZone;
 
 @SpringBootApplication
-public class QualimarcAPIApplication implements CommandLineRunner {
-    @Value("${jwt.anonymousUser}")
-    private String user;
-
-    @Autowired
-    private Environment env;
-
-    @Autowired
-    private JwtTokenProvider tokenProvider;
+public class QualimarcAPIApplication {
 
     public static void main(String[] args) {
-        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Paris"));   // It will set UTC timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Paris"));
         SpringApplication.run(QualimarcAPIApplication.class, args);
-    }
-
-    @Override
-    public void run(String... args) {
-        initSpringSecurity();
-    }
-
-    private void initSpringSecurity() {
-        List<GrantedAuthority> roles = new ArrayList<>();
-        roles.add(new SimpleGrantedAuthority("ANONYMOUS"));
-        String token = tokenProvider.generateToken();
-        Authentication auth = new AnonymousAuthenticationToken(token, user, roles);
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        System.out.println(token);
     }
 }

--- a/web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package fr.abes.qualimarc.web.security;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -16,6 +17,13 @@ public class JwtTokenProvider {
 
     @Value("${jwt.anonymousUser}")
     private String anonymousUser;
+
+    @PostConstruct
+    void validateConfiguration() {
+        if (!StringUtils.hasText(configuredToken)) {
+            throw new IllegalStateException("La propriété jwt.token doit être renseignée.");
+        }
+    }
 
     public boolean validateToken(String authToken) {
         if (!StringUtils.hasText(configuredToken) || !StringUtils.hasText(authToken)) {

--- a/web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java
@@ -1,59 +1,34 @@
 package fr.abes.qualimarc.web.security;
 
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.security.MessageDigest;
 
 @Component
-@Slf4j
 public class JwtTokenProvider {
 
-    @Value("${jwt.secret}")
-    private String secret;
+    @Value("${jwt.token:}")
+    private String configuredToken;
 
     @Value("${jwt.anonymousUser}")
     private String anonymousUser;
 
-    private SecretKey getSigningKey() {
-        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-    }
-
     public String generateToken() {
-        Calendar now = new GregorianCalendar(2099, 12, 31);
-        Date expiryDate = now.getTime();
-
-        return Jwts.builder()
-                .subject(anonymousUser)
-                .issuedAt(new Date())
-                .expiration(expiryDate)
-                .claim("role", "ANONYMOUS")
-                .signWith(getSigningKey(), SignatureAlgorithm.HS512)
-                .compact();
+        return configuredToken;
     }
-    public boolean validateToken(String authToken) {
-        try {
-            Jwts.parser()
-                    .verifyWith(getSigningKey())
-                    .build()
-                    .parseSignedClaims(authToken);
-            return true;
 
-        } catch (JwtException ex) {
-            log.error("Erreur d'authentification: {}", ex.getMessage());
+    public boolean validateToken(String authToken) {
+        if (!StringUtils.hasText(configuredToken) || !StringUtils.hasText(authToken)) {
             return false;
         }
+        return MessageDigest.isEqual(
+                configuredToken.getBytes(StandardCharsets.UTF_8),
+                authToken.getBytes(StandardCharsets.UTF_8)
+        );
     }
 
     public String getJwtFromRequest(HttpServletRequest request) {
@@ -65,11 +40,9 @@ public class JwtTokenProvider {
     }
 
     public String getUsernameFromJwtToken(String token) {
-        return Jwts.parser()
-                .verifyWith(getSigningKey())
-                .build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .getSubject();
+        if (!validateToken(token)) {
+            throw new IllegalArgumentException("Token API invalide");
+        }
+        return anonymousUser;
     }
 }

--- a/web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/security/JwtTokenProvider.java
@@ -17,10 +17,6 @@ public class JwtTokenProvider {
     @Value("${jwt.anonymousUser}")
     private String anonymousUser;
 
-    public String generateToken() {
-        return configuredToken;
-    }
-
     public boolean validateToken(String authToken) {
         if (!StringUtils.hasText(configuredToken) || !StringUtils.hasText(authToken)) {
             return false;

--- a/web/src/main/resources/application-dev.properties
+++ b/web/src/main/resources/application-dev.properties
@@ -27,7 +27,7 @@ spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
 jwt.anonymousUser=qualimarcUser
-jwt.token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxdWFsaW1hcmNVc2VyIiwiaWF0IjoxNzcwODI4NTU0LCJleHAiOjQxMDUwMzMyMDAsInJvbGUiOiJBTk9OWU1PVVMifQ.sTZjyv0reSj0JgL5KbuXkJ20BxkIoVpjQM8AhcusBYv30Liq0kpaoPFqibWcmo5sd4ZP3H8b90IMisYJJOgeig
+jwt.token=${JWT_TOKEN:}
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/main/resources/application-dev.properties
+++ b/web/src/main/resources/application-dev.properties
@@ -26,8 +26,8 @@ spring.jpa.basexml.hibernate.ddl-auto=none
 spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
-jwt.anonymousUser=
-jwt.secret=
+jwt.anonymousUser=qualimarcUser
+jwt.token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxdWFsaW1hcmNVc2VyIiwiaWF0IjoxNzcwODI4NTU0LCJleHAiOjQxMDUwMzMyMDAsInJvbGUiOiJBTk9OWU1PVVMifQ.sTZjyv0reSj0JgL5KbuXkJ20BxkIoVpjQM8AhcusBYv30Liq0kpaoPFqibWcmo5sd4ZP3H8b90IMisYJJOgeig
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/main/resources/application-dev.properties
+++ b/web/src/main/resources/application-dev.properties
@@ -27,7 +27,7 @@ spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
 jwt.anonymousUser=qualimarcUser
-jwt.token=${JWT_TOKEN:}
+jwt.token=${JWT_TOKEN:${JWT_SECRET:}}
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/main/resources/application-prod.properties
+++ b/web/src/main/resources/application-prod.properties
@@ -28,7 +28,7 @@ spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
 jwt.anonymousUser=qualimarcUser
-jwt.token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxdWFsaW1hcmNVc2VyIiwiaWF0IjoxNzcwODI4NTU0LCJleHAiOjQxMDUwMzMyMDAsInJvbGUiOiJBTk9OWU1PVVMifQ.sTZjyv0reSj0JgL5KbuXkJ20BxkIoVpjQM8AhcusBYv30Liq0kpaoPFqibWcmo5sd4ZP3H8b90IMisYJJOgeig
+jwt.token=${JWT_TOKEN:}
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/main/resources/application-prod.properties
+++ b/web/src/main/resources/application-prod.properties
@@ -27,8 +27,8 @@ spring.jpa.basexml.hibernate.ddl-auto=none
 spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
-jwt.anonymousUser=
-jwt.secret=
+jwt.anonymousUser=qualimarcUser
+jwt.token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxdWFsaW1hcmNVc2VyIiwiaWF0IjoxNzcwODI4NTU0LCJleHAiOjQxMDUwMzMyMDAsInJvbGUiOiJBTk9OWU1PVVMifQ.sTZjyv0reSj0JgL5KbuXkJ20BxkIoVpjQM8AhcusBYv30Liq0kpaoPFqibWcmo5sd4ZP3H8b90IMisYJJOgeig
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/main/resources/application-prod.properties
+++ b/web/src/main/resources/application-prod.properties
@@ -28,7 +28,7 @@ spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
 jwt.anonymousUser=qualimarcUser
-jwt.token=${JWT_TOKEN:}
+jwt.token=${JWT_TOKEN:${JWT_SECRET:}}
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/main/resources/application-test.properties
+++ b/web/src/main/resources/application-test.properties
@@ -28,7 +28,7 @@ spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
 jwt.anonymousUser=qualimarcUser
-jwt.token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxdWFsaW1hcmNVc2VyIiwiaWF0IjoxNzcwODI4NTU0LCJleHAiOjQxMDUwMzMyMDAsInJvbGUiOiJBTk9OWU1PVVMifQ.sTZjyv0reSj0JgL5KbuXkJ20BxkIoVpjQM8AhcusBYv30Liq0kpaoPFqibWcmo5sd4ZP3H8b90IMisYJJOgeig
+jwt.token=${JWT_TOKEN:}
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/main/resources/application-test.properties
+++ b/web/src/main/resources/application-test.properties
@@ -27,8 +27,8 @@ spring.jpa.basexml.hibernate.ddl-auto=none
 spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
-jwt.anonymousUser=
-jwt.secret=
+jwt.anonymousUser=qualimarcUser
+jwt.token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxdWFsaW1hcmNVc2VyIiwiaWF0IjoxNzcwODI4NTU0LCJleHAiOjQxMDUwMzMyMDAsInJvbGUiOiJBTk9OWU1PVVMifQ.sTZjyv0reSj0JgL5KbuXkJ20BxkIoVpjQM8AhcusBYv30Liq0kpaoPFqibWcmo5sd4ZP3H8b90IMisYJJOgeig
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/main/resources/application-test.properties
+++ b/web/src/main/resources/application-test.properties
@@ -28,7 +28,7 @@ spring.jpa.basexml.database-platform=org.hibernate.dialect.Oracle12cDialect
 spring.sql.basexml.init.mode=never
 
 jwt.anonymousUser=qualimarcUser
-jwt.token=${JWT_TOKEN:}
+jwt.token=${JWT_TOKEN:${JWT_SECRET:}}
 
 spring.task.execution.pool.core-size=8
 spring.task.execution.pool.max-size=8

--- a/web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java
@@ -1,14 +1,31 @@
 package fr.abes.qualimarc;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.CommandLineRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(OutputCaptureExtension.class)
 class QualimarcAPIApplicationTest {
 
     @Test
-    void applicationDoesNotImplementCommandLineRunnerAnymore() {
-        assertThat(CommandLineRunner.class.isAssignableFrom(QualimarcAPIApplication.class)).isFalse();
+    void startupDoesNotEmitConfiguredApiToken(CapturedOutput output) {
+        String configuredToken = "token-admin-qualimarc";
+        String[] args = {
+                "--jwt.token=" + configuredToken,
+                "--jwt.anonymousUser=qualimarcUser"
+        };
+
+        try (MockedStatic<SpringApplication> springApplication = Mockito.mockStatic(SpringApplication.class)) {
+            QualimarcAPIApplication.main(args);
+
+            assertThat(output).doesNotContain(configuredToken);
+            springApplication.verify(() -> SpringApplication.run(QualimarcAPIApplication.class, args));
+        }
     }
 }

--- a/web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/QualimarcAPIApplicationTest.java
@@ -1,0 +1,14 @@
+package fr.abes.qualimarc;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.CommandLineRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QualimarcAPIApplicationTest {
+
+    @Test
+    void applicationDoesNotImplementCommandLineRunnerAnymore() {
+        assertThat(CommandLineRunner.class.isAssignableFrom(QualimarcAPIApplication.class)).isFalse();
+    }
+}

--- a/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenConfigurationContractTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenConfigurationContractTest.java
@@ -33,4 +33,20 @@ class JwtTokenConfigurationContractTest {
         assertThat(resolver.getProperty("jwt.anonymousUser")).isEqualTo("qualimarcUser");
         assertThat(resolver.resolveRequiredPlaceholders(resolver.getProperty("jwt.token"))).isEqualTo("token-admin-injecte");
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application-dev.properties",
+            "application-test.properties",
+            "application-prod.properties"
+    })
+    void profilePropertiesFallbackToLegacyJwtSecretWhenJwtTokenIsAbsent(String profileProperties) throws IOException {
+        Properties properties = PropertiesLoaderUtils.loadProperties(new ClassPathResource(profileProperties));
+        MutablePropertySources propertySources = new MutablePropertySources();
+        propertySources.addFirst(new MapPropertySource("injectedEnvironment", Map.of("JWT_SECRET", "token-admin-legacy")));
+        propertySources.addLast(new PropertiesPropertySource("profileProperties", properties));
+        PropertySourcesPropertyResolver resolver = new PropertySourcesPropertyResolver(propertySources);
+
+        assertThat(resolver.resolveRequiredPlaceholders(resolver.getProperty("jwt.token"))).isEqualTo("token-admin-legacy");
+    }
 }

--- a/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenConfigurationContractTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenConfigurationContractTest.java
@@ -1,0 +1,36 @@
+package fr.abes.qualimarc.web.security;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySourcesPropertyResolver;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenConfigurationContractTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application-dev.properties",
+            "application-test.properties",
+            "application-prod.properties"
+    })
+    void profilePropertiesResolveJwtTokenFromInjectedEnvironmentValue(String profileProperties) throws IOException {
+        Properties properties = PropertiesLoaderUtils.loadProperties(new ClassPathResource(profileProperties));
+        MutablePropertySources propertySources = new MutablePropertySources();
+        propertySources.addFirst(new MapPropertySource("injectedEnvironment", Map.of("JWT_TOKEN", "token-admin-injecte")));
+        propertySources.addLast(new PropertiesPropertySource("profileProperties", properties));
+        PropertySourcesPropertyResolver resolver = new PropertySourcesPropertyResolver(propertySources);
+
+        assertThat(resolver.getProperty("jwt.anonymousUser")).isEqualTo("qualimarcUser");
+        assertThat(resolver.resolveRequiredPlaceholders(resolver.getProperty("jwt.token"))).isEqualTo("token-admin-injecte");
+    }
+}

--- a/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class JwtTokenProviderTest {
 
     private static final String EXPECTED_ANONYMOUS_USER = "jwt.anonymousUser=qualimarcUser";
-    private static final String EXPECTED_TOKEN = "jwt.token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxdWFsaW1hcmNVc2VyIiwiaWF0IjoxNzcwODI4NTU0LCJleHAiOjQxMDUwMzMyMDAsInJvbGUiOiJBTk9OWU1PVVMifQ.sTZjyv0reSj0JgL5KbuXkJ20BxkIoVpjQM8AhcusBYv30Liq0kpaoPFqibWcmo5sd4ZP3H8b90IMisYJJOgeig";
+    private static final String EXPECTED_TOKEN = "jwt.token=${JWT_TOKEN:}";
 
     private JwtTokenProvider createProvider() {
         JwtTokenProvider provider = new JwtTokenProvider();

--- a/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
@@ -1,0 +1,54 @@
+package fr.abes.qualimarc.web.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider createProvider() {
+        JwtTokenProvider provider = new JwtTokenProvider();
+        ReflectionTestUtils.setField(provider, "configuredToken", "token-admin-qualimarc");
+        ReflectionTestUtils.setField(provider, "anonymousUser", "qualimarcUser");
+        return provider;
+    }
+
+    @Test
+    void validateTokenReturnsTrueForConfiguredToken() {
+        JwtTokenProvider provider = createProvider();
+
+        assertThat(provider.validateToken("token-admin-qualimarc")).isTrue();
+    }
+
+    @Test
+    void validateTokenReturnsFalseForDifferentToken() {
+        JwtTokenProvider provider = createProvider();
+
+        assertThat(provider.validateToken("token-invalide")).isFalse();
+    }
+
+    @Test
+    void generateTokenReturnsConfiguredToken() {
+        JwtTokenProvider provider = createProvider();
+
+        assertThat(provider.generateToken()).isEqualTo("token-admin-qualimarc");
+    }
+
+    @Test
+    void getJwtFromRequestExtractsBearerToken() {
+        JwtTokenProvider provider = createProvider();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer token-admin-qualimarc");
+
+        assertThat(provider.getJwtFromRequest(request)).isEqualTo("token-admin-qualimarc");
+    }
+
+    @Test
+    void getUsernameFromJwtTokenReturnsConfiguredAnonymousUser() {
+        JwtTokenProvider provider = createProvider();
+
+        assertThat(provider.getUsernameFromJwtToken("token-admin-qualimarc")).isEqualTo("qualimarcUser");
+    }
+}

--- a/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
@@ -4,9 +4,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JwtTokenProviderTest {
+
+    private static final String EXPECTED_ANONYMOUS_USER = "jwt.anonymousUser=qualimarcUser";
+    private static final String EXPECTED_TOKEN = "jwt.token=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxdWFsaW1hcmNVc2VyIiwiaWF0IjoxNzcwODI4NTU0LCJleHAiOjQxMDUwMzMyMDAsInJvbGUiOiJBTk9OWU1PVVMifQ.sTZjyv0reSj0JgL5KbuXkJ20BxkIoVpjQM8AhcusBYv30Liq0kpaoPFqibWcmo5sd4ZP3H8b90IMisYJJOgeig";
 
     private JwtTokenProvider createProvider() {
         JwtTokenProvider provider = new JwtTokenProvider();
@@ -43,5 +51,18 @@ class JwtTokenProviderTest {
         JwtTokenProvider provider = createProvider();
 
         assertThat(provider.getUsernameFromJwtToken("token-admin-qualimarc")).isEqualTo("qualimarcUser");
+    }
+
+    @Test
+    void profilePropertiesExposeTheSameJwtContract() throws IOException {
+        assertProfileJwtContract("src/main/resources/application-dev.properties");
+        assertProfileJwtContract("src/main/resources/application-test.properties");
+        assertProfileJwtContract("src/main/resources/application-prod.properties");
+    }
+
+    private void assertProfileJwtContract(String relativePath) throws IOException {
+        List<String> lines = Files.readAllLines(Path.of(relativePath));
+
+        assertThat(lines).contains(EXPECTED_ANONYMOUS_USER, EXPECTED_TOKEN);
     }
 }

--- a/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
@@ -4,21 +4,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JwtTokenProviderTest {
 
-    private static final String EXPECTED_ANONYMOUS_USER = "jwt.anonymousUser=qualimarcUser";
-    private static final String EXPECTED_TOKEN = "jwt.token=${JWT_TOKEN:}";
-
     private JwtTokenProvider createProvider() {
+        return createProvider("token-admin-qualimarc");
+    }
+
+    private JwtTokenProvider createProvider(String configuredToken) {
         JwtTokenProvider provider = new JwtTokenProvider();
-        ReflectionTestUtils.setField(provider, "configuredToken", "token-admin-qualimarc");
+        ReflectionTestUtils.setField(provider, "configuredToken", configuredToken);
         ReflectionTestUtils.setField(provider, "anonymousUser", "qualimarcUser");
         return provider;
     }
@@ -54,15 +51,20 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    void profilePropertiesExposeTheSameJwtContract() throws IOException {
-        assertProfileJwtContract("src/main/resources/application-dev.properties");
-        assertProfileJwtContract("src/main/resources/application-test.properties");
-        assertProfileJwtContract("src/main/resources/application-prod.properties");
+    void validateConfigurationRejectsMissingConfiguredToken() {
+        JwtTokenProvider provider = createProvider(null);
+
+        assertThatThrownBy(provider::validateConfiguration)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("jwt.token");
     }
 
-    private void assertProfileJwtContract(String relativePath) throws IOException {
-        List<String> lines = Files.readAllLines(Path.of(relativePath));
+    @Test
+    void validateConfigurationRejectsBlankConfiguredToken() {
+        JwtTokenProvider provider = createProvider("   ");
 
-        assertThat(lines).contains(EXPECTED_ANONYMOUS_USER, EXPECTED_TOKEN);
+        assertThatThrownBy(provider::validateConfiguration)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("jwt.token");
     }
 }

--- a/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/security/JwtTokenProviderTest.java
@@ -30,13 +30,6 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    void generateTokenReturnsConfiguredToken() {
-        JwtTokenProvider provider = createProvider();
-
-        assertThat(provider.generateToken()).isEqualTo("token-admin-qualimarc");
-    }
-
-    @Test
     void getJwtFromRequestExtractsBearerToken() {
         JwtTokenProvider provider = createProvider();
         MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
## Resume\n- propage sur main la suppression de la generation du token au demarrage\n- harmonise la validation du token API entre les environnements\n- conserve le repli transitoire sur JWT_SECRET pour les deploiements Docker existants\n\n## Verification\n- mvn -pl web test sur la branche source\n