### PR TITLE
Optimise les performances d'analyse

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/notice/NoticeXml.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/notice/NoticeXml.java
@@ -14,12 +14,15 @@ import lombok.Setter;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * Représente une notice au format d'export UnimarcXML
+ * ReprÃ©sente une notice au format d'export UnimarcXML
  */
 @NoArgsConstructor
 @Getter
@@ -36,75 +39,72 @@ public class NoticeXml {
     @JacksonXmlProperty(localName = "datafield")
     private List<Datafield> datafields;
 
+    private transient Map<String, Controlfield> controlfieldsByTag;
+
+    private transient Map<String, List<Datafield>> datafieldsByTag;
+
     @Override
     public String toString() {
         return "Notice {" + "leader=" + leader + "}";
     }
 
     /**
-     * Récupère le titre en 200$a
+     * RÃ©cupÃ¨re le titre en 200$a
      * @return
      * @throws ZoneNotFoundException
      */
     public String getTitre() throws ZoneNotFoundException {
-        Optional<Datafield> zone200 = this.datafields.stream().filter(datafield -> datafield.getTag().equals("200")).findFirst();
-        if(zone200.isPresent()){
-            Optional<SubField> sousZone_a = zone200.get().getSubFields().stream().filter(subField -> subField.getCode().equals("a")).findFirst();
-            if(sousZone_a.isPresent()){
-                return sousZone_a.get().getValue().replaceAll("\\p{C}", "");
-            }
-        }
-        throw new TitreNotFoundException("Titre non renseigné");
+        return getDatafieldsByTag("200").stream()
+                .flatMap(datafield -> datafield.getSubFields().stream())
+                .filter(subField -> subField.getCode().equals("a"))
+                .map(subField -> subField.getValue().replaceAll("\\p{C}", ""))
+                .findFirst()
+                .orElseThrow(() -> new TitreNotFoundException("Titre non renseigné"));
     }
 
     /**
-     * Récupère l'auteur en 200 $f
+     * RÃ©cupÃ¨re l'auteur en 200 $f
      * @return
      * @throws ZoneNotFoundException
      */
     public String getAuteur() throws ZoneNotFoundException {
-        Optional<Datafield> zone200 = this.datafields.stream().filter(datafield -> datafield.getTag().equals("200")).findFirst();
-        if(zone200.isPresent()){
-            Optional<SubField> sousZone_f = zone200.get().getSubFields().stream().filter(subField -> subField.getCode().equals("f")).findFirst();
-            if(sousZone_f.isPresent()){
-                return sousZone_f.get().getValue();
-            }
-        }
-        throw new AuteurNotFoundException("Auteur non renseigné");
+        return getDatafieldsByTag("200").stream()
+                .flatMap(datafield -> datafield.getSubFields().stream())
+                .filter(subField -> subField.getCode().equals("f"))
+                .map(SubField::getValue)
+                .findFirst()
+                .orElseThrow(() -> new AuteurNotFoundException("Auteur non renseigné"));
     }
 
     /**
-     * Récupère l'ISBN en 010 $a
+     * RÃ©cupÃ¨re l'ISBN en 010 $a
      * @return
      */
     public String getIsbn(){
-        Optional<Datafield> zone010 = this.datafields.stream().filter(datafield -> datafield.getTag().equals("010")).findFirst();
-        if(zone010.isPresent()){
-            Optional<SubField> sousZone_a_A = zone010.get().getSubFields().stream().filter(subField -> subField.getCode().equals("a")).findFirst();
-            if(sousZone_a_A.isPresent()){
-                return sousZone_a_A.get().getValue();
-            }
-        }
-        return null;
+        return getDatafieldsByTag("010").stream()
+                .flatMap(datafield -> datafield.getSubFields().stream())
+                .filter(subField -> subField.getCode().equals("a"))
+                .map(SubField::getValue)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
-     * Récupère l'OCN en 034 $a
+     * RÃ©cupÃ¨re l'OCN en 034 $a
      * @return
      */
     public String getOcn() {
-        Optional<Datafield> zone034 = this.datafields.stream().filter(datafield -> datafield.getTag().equals("034")).findFirst();
-        if(zone034.isPresent()){
-            Optional<SubField> sousZonea = zone034.get().getSubFields().stream().filter(subField -> subField.getCode().equals("a") && subField.getValue().startsWith("(OCoLC)")).findFirst();
-            if(sousZonea.isPresent()){
-                return sousZonea.get().getValue().substring(7);
-            }
-        }
-        return null;
+        return getDatafieldsByTag("034").stream()
+                .flatMap(datafield -> datafield.getSubFields().stream())
+                .filter(subField -> subField.getCode().equals("a") && subField.getValue().startsWith("(OCoLC)"))
+                .map(SubField::getValue)
+                .map(value -> value.substring(7))
+                .findFirst()
+                .orElse(null);
     }
 
     /**
-     * Indique si la notice est en état supprimée
+     * Indique si la notice est en Ã©tat supprimÃ©e
      * @return
      */
     public boolean isDeleted() {
@@ -112,14 +112,14 @@ public class NoticeXml {
     }
 
     /**
-     * Récupère la date de modification de la notice : si la notice n'a pas été modifiée la date de création est quand même en 005
+     * RÃ©cupÃ¨re la date de modification de la notice : si la notice n'a pas Ã©tÃ© modifiÃ©e la date de crÃ©ation est quand mÃªme en 005
      * @return la date au format dd/MM/yyyy
      * @throws ParseException
      */
     public String getDateModification() throws ParseException {
         DateFormat dateFormatIn = new SimpleDateFormat("yyyyMMdd");
         DateFormat dateFormatOut = new SimpleDateFormat("dd/MM/yyyy");
-        Optional<Controlfield> zone005 = this.controlfields.stream().filter(zone -> zone.getTag().equals("005")).findFirst();
+        Optional<Controlfield> zone005 = getControlfieldByTag("005");
         if (zone005.isPresent()) {
             String dateModif = zone005.get().getValue().substring(0, 8);
             return dateFormatOut.format(dateFormatIn.parse(dateModif));
@@ -128,20 +128,17 @@ public class NoticeXml {
     }
 
     /**
-     * Récupère le RCR du dernier utilisateur ayant modifié la notice (ou créé si la notice n'a jamais été modifiée)
+     * RÃ©cupÃ¨re le RCR du dernier utilisateur ayant modifiÃ© la notice (ou crÃ©Ã© si la notice n'a jamais Ã©tÃ© modifiÃ©e)
      * @return
      */
     public String getRcr() {
-        Optional<Controlfield> zone007 =  this.controlfields.stream().filter(zone -> zone.getTag().equals("007")).findFirst();
-        if (zone007.isPresent())
-            return zone007.get().getValue();
-        return null;
+        return getControlfieldByTag("007").map(Controlfield::getValue).orElse(null);
     }
 
     /**
-     * Retourne le type de document de la notice en se basant sur les caractères en position 6 et 7 du leader
+     * Retourne le type de document de la notice en se basant sur les caractÃ¨res en position 6 et 7 du leader
      *
-     * @return les 2 caractères du code correspondant au type de document
+     * @return les 2 caractÃ¨res du code correspondant au type de document
      */
     public String getTypeDocument() {
         if (this.leader.length() >= 9)
@@ -150,52 +147,41 @@ public class NoticeXml {
     }
 
     /**
-     * Analyse le type de document d'une notice pour en déduire la famille de type de document
+     * Analyse le type de document d'une notice pour en dÃ©duire la famille de type de document
      *
      * @return famille de type de document
      */
     public String getFamilleDocument() {
         switch (this.getTypeDocument()) {
-            //Famille AUDIOVISUEL
             case "gm":
             case "gc":
                 return "B";
-            //FAMILLE CARTE
             case "em":
             case "ed":
             case "fm":
                 return "K";
-            //FAMILLE DOCUMENT ELECTRONIQUE
             case "lm":
             case "lc":
                 return "O";
-            //FAMILLE ENREGISTREMENT
             case "im":
             case "id":
                 return "N";
-            //FAMILLE IMAGE
             case "km":
             case "kc":
                 return "I";
-            //FAMILLE MANUSCRIT
             case "bm":
                 return "F";
-            //FAMILLE MULTIMEDIA
             case "mm":
             case "mc":
                 return "Z";
-            //FAMILLE MUSIQUE
             case "jm":
                 return "G";
-            //FAMILLE OBJET
             case "rm":
                 return "V";
-            //FAMILLE PARTITION
             case "dm":
             case "cm":
             case "cc":
                 return "M";
-            //FAMILLE RESSOURCE CONTINUE
             case "as":
             case "gs":
             case "ls":
@@ -209,11 +195,9 @@ public class NoticeXml {
             case "ad":
             case "ai":
                 return "BD";
-            //FAMILLE MONOGRAPHIE
             case "am":
             case "ac":
                 return "A";
-            //FAMILLE PARTIE COMPOSANTE
             case "aa":
             case "la":
             case "ga":
@@ -224,23 +208,24 @@ public class NoticeXml {
     }
 
     public String getPpnLieFromZone(String zone, String sousZone) {
-        List<Datafield> datafields = this.getDatafields().stream().filter(datafield -> datafield.getTag().equals(zone)).collect(Collectors.toList());
-        for (Datafield datafield : datafields) {
-            List<SubField> subFields = datafield.getSubFields().stream().filter(subField -> subField.getCode().equals(sousZone)).collect(Collectors.toList());
-            if (subFields.isEmpty())
+        for (Datafield datafield : getDatafieldsByTag(zone)) {
+            List<SubField> subFields = datafield.getSubFields().stream()
+                    .filter(subField -> subField.getCode().equals(sousZone))
+                    .collect(Collectors.toList());
+            if (subFields.isEmpty()) {
                 return null;
+            }
             return subFields.get(0).getValue();
         }
-        //pas de zone/sous zone trouvée
         return null;
     }
 
     /**
-     * Teste le type de thèse de la notice
-     * @return TypeThese.REPRO si la notice est une thèse de reproduction, TypeThese.SOUTENANCE si la notice est une thèse de soutenance, null si la notice n'est pas une thèse
+     * Teste le type de thÃ¨se de la notice
+     * @return TypeThese.REPRO si la notice est une thÃ¨se de reproduction, TypeThese.SOUTENANCE si la notice est une thÃ¨se de soutenance, null si la notice n'est pas une thÃ¨se
      */
     public TypeThese getTypeThese() {
-        Optional<Datafield> zone105Opt = this.getDatafields().stream().filter(zone -> zone.getTag().equals("105")).findFirst();
+        Optional<Datafield> zone105Opt = getDatafieldsByTag("105").stream().findFirst();
         if (zone105Opt.isPresent()) {
             Datafield zone105 = zone105Opt.get();
             Optional<SubField> aOpt = zone105.getSubFields().stream().filter(sousZone -> sousZone.getCode().equals("a")).findFirst();
@@ -260,7 +245,38 @@ public class NoticeXml {
     }
 
     public String getPpn() {
-        Optional<Controlfield> ppn = controlfields.stream().filter(cf -> cf.getTag().equals("001")).findFirst();
-        return ppn.map(Controlfield::getValue).orElse(null);
+        return getControlfieldByTag("001").map(Controlfield::getValue).orElse(null);
+    }
+
+    public void setControlfields(List<Controlfield> controlfields) {
+        this.controlfields = controlfields;
+        this.controlfieldsByTag = null;
+    }
+
+    public void setDatafields(List<Datafield> datafields) {
+        this.datafields = datafields;
+        this.datafieldsByTag = null;
+    }
+
+    private Optional<Controlfield> getControlfieldByTag(String tag) {
+        if (controlfields == null || controlfields.isEmpty()) {
+            return Optional.empty();
+        }
+        if (controlfieldsByTag == null) {
+            controlfieldsByTag = controlfields.stream()
+                    .collect(Collectors.toMap(Controlfield::getTag, controlfield -> controlfield, (left, right) -> left, HashMap::new));
+        }
+        return Optional.ofNullable(controlfieldsByTag.get(tag));
+    }
+
+    private List<Datafield> getDatafieldsByTag(String tag) {
+        if (datafields == null || datafields.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (datafieldsByTag == null) {
+            datafieldsByTag = datafields.stream()
+                    .collect(Collectors.groupingBy(Datafield::getTag, HashMap::new, Collectors.toList()));
+        }
+        return datafieldsByTag.getOrDefault(tag, Collections.emptyList());
     }
 }

--- a/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/ComplexRule.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/ComplexRule.java
@@ -77,6 +77,9 @@ public class ComplexRule implements Serializable {
     @Transient
     private List<Datafield> savedZone = new ArrayList<>();
 
+    @Transient
+    private List<OtherRule> orderedOtherRules;
+
     protected ComplexRule(){}
 
     public ComplexRule(Integer id, String message, Priority priority, Set<FamilleDocument> famillesDocuments, Set<TypeThese> typesThese, SimpleRule firstRule, List<OtherRule> otherRules) {
@@ -143,6 +146,12 @@ public class ComplexRule implements Serializable {
 
     public void addOtherRule(OtherRule otherRule) {
         this.otherRules.add(otherRule);
+        this.orderedOtherRules = null;
+    }
+
+    public void setOtherRules(List<OtherRule> otherRules) {
+        this.otherRules = otherRules;
+        this.orderedOtherRules = null;
     }
 
     /**
@@ -195,7 +204,7 @@ public class ComplexRule implements Serializable {
     private boolean isValidTwoNotices(NoticeXml notice, NoticeXml noticeLiee) {
         boolean isValid = firstRule.isValid(notice);
         boolean isDependencyFound = false;
-        for (OtherRule otherRule : otherRules.stream().sorted(Comparator.comparing(OtherRule::getPosition)).collect(Collectors.toList())) {
+        for (OtherRule otherRule : getOrderedOtherRules()) {
             if (otherRule instanceof DependencyRule) {
                 //dès qu'on trouve une règle de dépendance dans les linked rule, on informe le programme qu'il doit appliquer les règles suivantes sur la notice liée
                 isDependencyFound = true;
@@ -232,7 +241,7 @@ public class ComplexRule implements Serializable {
         this.savedZone.clear();
         boolean isValid = firstRule.isValid(notice);
 
-        for (OtherRule otherRule : otherRules.stream().sorted(Comparator.comparing(OtherRule::getPosition)).collect(Collectors.toList())) {
+        for (OtherRule otherRule : getOrderedOtherRules()) {
             LinkedRule linkedRule = (LinkedRule) otherRule;
             switch (linkedRule.getOperateur()) {
                 case ET:
@@ -248,6 +257,18 @@ public class ComplexRule implements Serializable {
             }
         }
         return isValid;
+    }
+
+    List<OtherRule> getOrderedOtherRules() {
+        if (otherRules == null || otherRules.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (orderedOtherRules == null) {
+            orderedOtherRules = otherRules.stream()
+                    .sorted(Comparator.comparing(OtherRule::getPosition))
+                    .toList();
+        }
+        return orderedOtherRules;
     }
 
     public List<String> getZonesFromChildren() {

--- a/core/src/main/java/fr/abes/qualimarc/core/service/NoticeService.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/service/NoticeService.java
@@ -24,6 +24,8 @@ import java.util.stream.Collectors;
 public class NoticeService {
     private static final List<String> zonesLocales = List.of("012", "035", "316", "317", "318", "600", "601", "602", "606", "607", "608", "676", "680", "681", "701", "702", "712", "722");
     private static final List<String> zonesExemplaires = List.of("012", "316", "317", "318", "621", "702", "712", "722", "856");
+    private static final XmlMapper XML_MAPPER = buildXmlMapper();
+
     @Autowired
     private NoticesBibioRepository repositoryBiblio;
 
@@ -71,6 +73,10 @@ public class NoticeService {
     }
 
     private XmlMapper getMapper() {
+        return XML_MAPPER;
+    }
+
+    private static XmlMapper buildXmlMapper() {
         JacksonXmlModule module = new JacksonXmlModule();
         module.setDefaultUseWrapper(false);
         return new XmlMapper(module);

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/basexml/NoticeXmlTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/basexml/NoticeXmlTest.java
@@ -267,4 +267,46 @@ public class NoticeXmlTest {
         Assertions.assertEquals("143519379", notice.getPpn());
     }
 
+    @Test
+    void refreshDatafieldLookupWhenDatafieldsChange() throws ZoneNotFoundException {
+        NoticeXml notice = new NoticeXml();
+        Datafield firstTitleField = new Datafield();
+        firstTitleField.setTag("200");
+        SubField firstTitle = new SubField();
+        firstTitle.setCode("a");
+        firstTitle.setValue("Premier titre");
+        firstTitleField.setSubFields(Lists.newArrayList(firstTitle));
+        notice.setDatafields(Lists.newArrayList(firstTitleField));
+
+        Assertions.assertEquals("Premier titre", notice.getTitre());
+
+        Datafield secondTitleField = new Datafield();
+        secondTitleField.setTag("200");
+        SubField secondTitle = new SubField();
+        secondTitle.setCode("a");
+        secondTitle.setValue("Second titre");
+        secondTitleField.setSubFields(Lists.newArrayList(secondTitle));
+        notice.setDatafields(Lists.newArrayList(secondTitleField));
+
+        Assertions.assertEquals("Second titre", notice.getTitre());
+    }
+
+    @Test
+    void refreshControlfieldLookupWhenControlfieldsChange() {
+        NoticeXml notice = new NoticeXml();
+        Controlfield firstControlfield = new Controlfield();
+        firstControlfield.setTag("001");
+        firstControlfield.setValue("111111111");
+        notice.setControlfields(Lists.newArrayList(firstControlfield));
+
+        Assertions.assertEquals("111111111", notice.getPpn());
+
+        Controlfield secondControlfield = new Controlfield();
+        secondControlfield.setTag("001");
+        secondControlfield.setValue("222222222");
+        notice.setControlfields(Lists.newArrayList(secondControlfield));
+
+        Assertions.assertEquals("222222222", notice.getPpn());
+    }
+
 }

--- a/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/ComplexRuleTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/model/entity/qualimarc/rules/ComplexRuleTest.java
@@ -24,6 +24,7 @@ import org.springframework.core.io.Resource;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.TreeSet;
 
 @SpringBootTest(classes = {ComplexRule.class})
@@ -67,6 +68,19 @@ public class ComplexRuleTest {
 
         complexRule.addOtherRule(new LinkedRule(new PresenceSousZone(4, "033", false, "a", true), BooleanOperateur.OU, 1, complexRule));
         Assertions.assertTrue(complexRule.isValid(notice));
+    }
+
+    @Test
+    void complexRuleUsesLinkedRulesInPositionOrder() {
+        ComplexRule complexRule = new ComplexRule(1, "test", Priority.P1, new PresenceZone(1, "010", false, true));
+        complexRule.addOtherRule(new LinkedRule(new PresenceZone(3, "200", false, true), BooleanOperateur.ET, 3, complexRule));
+        complexRule.addOtherRule(new LinkedRule(new PresenceZone(2, "011", false, false), BooleanOperateur.ET, 2, complexRule));
+
+        List<Integer> positions = complexRule.getOrderedOtherRules().stream()
+                .map(OtherRule::getPosition)
+                .toList();
+
+        Assertions.assertEquals(List.of(2, 3), positions);
     }
 
     @Test

--- a/web/src/main/java/fr/abes/qualimarc/web/controller/RuleController.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/controller/RuleController.java
@@ -117,11 +117,17 @@ public class RuleController {
         this.mapIdToNbTotalPpn.put(requestBody.getId(), requestBody.getPpnList().size());
         List<List<String>> splittedList = Lists.partition(requestBody.getPpnList(), requestBody.getPpnList().size() / nbThread + 1);
         List<CompletableFuture<ResultAnalyse>> resultList = new ArrayList<>();
+        Set<ComplexRule> rulesToApply = ruleService.getResultRulesList(
+                requestBody.getTypeAnalyse(),
+                familleDocuments,
+                typeThese,
+                ruleSets
+        );
 
         ResultAnalyse resultAnalyse;
         if(splittedList.size() > 1) {
             for (List<String> ppnList : splittedList)
-                resultList.add(ruleService.checkRulesOnNotices(requestBody.getId(), ruleService.getResultRulesList(requestBody.getTypeAnalyse(), familleDocuments, typeThese, ruleSets), ppnList, requestBody.isReplayed()));
+                resultList.add(ruleService.checkRulesOnNotices(requestBody.getId(), rulesToApply, ppnList, requestBody.isReplayed()));
 
             //biFunction permet de prendre le résultat de 2 traitements en parallèle et de les fusionner en un troisième qui est retourné
             BiFunction<ResultAnalyse, ResultAnalyse, ResultAnalyse> biFunction = (res1, res2) -> {
@@ -132,7 +138,7 @@ public class RuleController {
             //on récupère chaque traitement lancé en parallèle et on le combine au précédent en fusionnant les résultats
             resultAnalyse = resultList.stream().reduce((res1, res2) -> res1.thenCombineAsync(res2, biFunction, asyncExecutor)).orElse(CompletableFuture.completedFuture(new ResultAnalyse())).join();
         } else {
-            resultAnalyse = ruleService.checkRulesOnNotices(requestBody.getId(), ruleService.getResultRulesList(requestBody.getTypeAnalyse(), familleDocuments, typeThese, ruleSets), requestBody.getPpnList(), requestBody.isReplayed()).join();
+            resultAnalyse = ruleService.checkRulesOnNotices(requestBody.getId(), rulesToApply, requestBody.getPpnList(), requestBody.isReplayed()).join();
         }
 
         journalAnalyse.setNbPpnAnalyse(resultAnalyse.getPpnAnalyses().size());

--- a/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
@@ -33,6 +33,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -161,6 +162,33 @@ public class RuleControllerTest {
                 .andExpect(jsonPath("$.resultRules[1].ppn").value("123456789"))
                 .andExpect(jsonPath("$.resultRules[2].ppn").value("987654321"))
                 .andExpect(jsonPath("$.resultRules[3].ppn").value("654987321"));
+    }
+
+    @Test
+    void checkPpnWithMultiThreadLoadsRulesOnlyOnce() throws Exception {
+        Mockito.doNothing().when(journalService).saveJournalAnalyse(Mockito.any());
+        Mockito.when(utilsMapper.map(any(), any())).thenReturn(new ResultAnalyseResponseDto());
+        Mockito.when(ruleService.getResultRulesList(Mockito.eq(TypeAnalyse.QUICK), Mockito.anySet(), Mockito.anySet(), Mockito.anySet()))
+                .thenReturn(Collections.emptySet());
+
+        ResultAnalyse resultAnalyse = new ResultAnalyse();
+        resultAnalyse.setPpnAnalyses(Sets.newLinkedHashSet("143519379", "123456789", "987654321", "654987321"));
+        Mockito.when(ruleService.checkRulesOnNotices(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(CompletableFuture.completedFuture(resultAnalyse));
+
+        PpnWithRuleSetsRequestDto request = new PpnWithRuleSetsRequestDto();
+        request.setId(42);
+        request.setPpnList(List.of("143519379", "123456789", "987654321", "654987321"));
+        request.setTypeAnalyse(TypeAnalyse.QUICK);
+
+        this.mockMvc.perform(post("/api/v1/check")
+                        .accept(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        Mockito.verify(ruleService, Mockito.times(1))
+                .getResultRulesList(Mockito.eq(TypeAnalyse.QUICK), Mockito.anySet(), Mockito.anySet(), Mockito.anySet());
     }
 
     @Test


### PR DESCRIPTION
## Résumé\n- charge le référentiel de règles une seule fois par analyse\n- mutualise le parseur XML et indexe les champs de notice\n- évite les tris répétés des règles liées\n\n## Vérifications\n- mvn test