### PR TITLE
Rend l'analyse de l'API asynchrone

### DIFF
--- a/core/src/main/java/fr/abes/qualimarc/core/service/RuleService.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/service/RuleService.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -55,7 +56,7 @@ public class RuleService {
 
 
     //Map d'id de session d'utilisateur avec son pourcentage d'avancement d'analyse (threadsafe)
-    private final Map<Integer,AtomicInteger> idToCn = new HashMap<>();
+    private final Map<Integer,AtomicInteger> idToCn = new ConcurrentHashMap<>();
 
     @Async("asyncExecutor")
     public CompletableFuture<ResultAnalyse> checkRulesOnNotices(Integer id, Set<ComplexRule> rulesList, List<String> ppns, boolean isReplayed) {
@@ -247,14 +248,15 @@ public class RuleService {
     }
 
     public void resetCn(Integer id) {
-        if(!isCnPresent(id)){
-            this.idToCn.put(id,new AtomicInteger(0));
-        }
-        this.idToCn.get(id).getAndSet(0);
+        this.idToCn.computeIfAbsent(id, k -> new AtomicInteger(0)).getAndSet(0);
+    }
+
+    public void clearCn(Integer id) {
+        this.idToCn.remove(id);
     }
 
     public boolean isCnPresent(Integer id){
-        return !(this.idToCn.get(id) == null);
+        return this.idToCn.containsKey(id);
 
     }
     public List<ComplexRule> getAllComplexRules() {

--- a/web/src/main/java/fr/abes/qualimarc/web/controller/RuleController.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/controller/RuleController.java
@@ -15,13 +15,28 @@ import fr.abes.qualimarc.core.service.ReferenceService;
 import fr.abes.qualimarc.core.service.RuleService;
 import fr.abes.qualimarc.core.utils.TypeThese;
 import fr.abes.qualimarc.core.utils.UtilsMapper;
+import fr.abes.qualimarc.web.dto.AnalysisLaunchResponseDto;
 import fr.abes.qualimarc.web.dto.PpnWithRuleSetsRequestDto;
 import fr.abes.qualimarc.web.dto.ResultAnalyseResponseDto;
 import fr.abes.qualimarc.web.dto.RuleWebDto;
-import fr.abes.qualimarc.web.dto.indexrules.*;
-import fr.abes.qualimarc.web.dto.indexrules.contenu.*;
+import fr.abes.qualimarc.web.dto.indexrules.ComplexRuleWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.DependencyWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.ListComplexRulesWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.ListRulesWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.SimpleRuleWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.contenu.ComparaisonContenuSousZoneWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.contenu.ComparaisonDateWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.contenu.IndicateurWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.contenu.NombreCaracteresWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.contenu.PresenceChaineCaracteresWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.contenu.TypeCaractereWebDto;
 import fr.abes.qualimarc.web.dto.indexrules.dependance.ReciprociteWebDto;
-import fr.abes.qualimarc.web.dto.indexrules.structure.*;
+import fr.abes.qualimarc.web.dto.indexrules.structure.NombreSousZoneWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.structure.NombreZoneWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.structure.PositionSousZoneWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.structure.PresenceSousZoneWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.structure.PresenceSousZonesMemeZoneWebDto;
+import fr.abes.qualimarc.web.dto.indexrules.structure.PresenceZoneWebDto;
 import fr.abes.qualimarc.web.dto.reference.FamilleDocumentWebDto;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -31,13 +46,29 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -62,7 +93,9 @@ public class RuleController {
     @Value("${spring.task.execution.pool.core-size}")
     private Integer nbThread;
 
-    private final Map<Integer,Integer> mapIdToNbTotalPpn = new HashMap<>();
+    private final Map<Integer,Integer> mapIdToNbTotalPpn = new ConcurrentHashMap<>();
+
+    private final Map<Integer, CompletableFuture<ResultAnalyseResponseDto>> analysisResultsById = new ConcurrentHashMap<>();
 
     public RuleController(NoticeService noticeService, RuleService ruleService, ReferenceService referenceService, JournalService journalService, UtilsMapper mapper, @Qualifier("asyncExecutor") Executor asyncExecutor) {
         this.noticeService = noticeService;
@@ -79,11 +112,51 @@ public class RuleController {
     }
 
     @PostMapping(value = "/check", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResultAnalyseResponseDto checkPpn(@Valid @RequestBody PpnWithRuleSetsRequestDto requestBody) {
+    public ResponseEntity<AnalysisLaunchResponseDto> checkPpn(@Valid @RequestBody PpnWithRuleSetsRequestDto requestBody) {
+        int analysisId = requestBody.getId();
+
+        cleanupAnalysis(analysisId);
+        ruleService.resetCn(analysisId);
+        mapIdToNbTotalPpn.put(analysisId, requestBody.getPpnList().size());
+
         long start = System.currentTimeMillis();
-        ruleService.resetCn(requestBody.getId());
+        CompletableFuture<ResultAnalyseResponseDto> analysisFuture = CompletableFuture.supplyAsync(
+                () -> executeAnalysis(requestBody, start),
+                asyncExecutor
+        );
+        analysisFuture.whenComplete((result, throwable) -> {
+            if (throwable != null) {
+                log.error("Erreur inattendue pendant l'analyse {}", analysisId, throwable);
+            }
+        });
+        analysisResultsById.put(analysisId, analysisFuture);
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(new AnalysisLaunchResponseDto(analysisId));
+    }
+
+    @GetMapping("/result/{id}")
+    public ResponseEntity<ResultAnalyseResponseDto> getResult(@PathVariable int id) {
+        CompletableFuture<ResultAnalyseResponseDto> analysisFuture = analysisResultsById.get(id);
+        if (analysisFuture == null) {
+            throw new IllegalArgumentException("L'identifiant pour obtenir le resultat de l'analyse est incorrect, Actualiser votre page");
+        }
+
+        if (!analysisFuture.isDone()) {
+            return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+        }
+
+        try {
+            ResultAnalyseResponseDto result = analysisFuture.join();
+            cleanupAnalysis(id);
+            return ResponseEntity.ok(result);
+        } catch (CompletionException ex) {
+            cleanupAnalysis(id);
+            throw new IllegalStateException("Une erreur inattendue est survenue pendant l'analyse", ex.getCause());
+        }
+    }
+
+    private ResultAnalyseResponseDto executeAnalysis(PpnWithRuleSetsRequestDto requestBody, long start) {
         Date dateJour = Calendar.getInstance().getTime();
-        //initialisation de l'entrée dans la table journée
         JournalAnalyse journalAnalyse = new JournalAnalyse(dateJour, requestBody.getTypeAnalyse(), requestBody.isReplayed());
         Set<RuleSet> ruleSets = new HashSet<>();
         Set<FamilleDocument> familleDocuments =  new HashSet<>();
@@ -99,7 +172,6 @@ public class RuleController {
             for (TypeThese enumTypeThese : EnumUtils.getEnumList(TypeThese.class)) {
                 if (requestBody.getFamilleDocumentSet().stream().map(FamilleDocumentWebDto::getId).collect(Collectors.toList()).contains(enumTypeThese.name())) {
                     typeThese.add(enumTypeThese);
-                    //suppression du type these de la requête pour ne pas altérer la récupération de familles de documents dans la base
                     requestBody.getFamilleDocumentSet().removeIf(f -> f.getId().equals(enumTypeThese.name()));
                 }
             }
@@ -114,7 +186,6 @@ public class RuleController {
                 });
             }
         }
-        this.mapIdToNbTotalPpn.put(requestBody.getId(), requestBody.getPpnList().size());
         List<List<String>> splittedList = Lists.partition(requestBody.getPpnList(), requestBody.getPpnList().size() / nbThread + 1);
         List<CompletableFuture<ResultAnalyse>> resultList = new ArrayList<>();
         Set<ComplexRule> rulesToApply = ruleService.getResultRulesList(
@@ -126,16 +197,15 @@ public class RuleController {
 
         ResultAnalyse resultAnalyse;
         if(splittedList.size() > 1) {
-            for (List<String> ppnList : splittedList)
+            for (List<String> ppnList : splittedList) {
                 resultList.add(ruleService.checkRulesOnNotices(requestBody.getId(), rulesToApply, ppnList, requestBody.isReplayed()));
+            }
 
-            //biFunction permet de prendre le résultat de 2 traitements en parallèle et de les fusionner en un troisième qui est retourné
             BiFunction<ResultAnalyse, ResultAnalyse, ResultAnalyse> biFunction = (res1, res2) -> {
                 res1.merge(res2);
                 return res1;
             };
 
-            //on récupère chaque traitement lancé en parallèle et on le combine au précédent en fusionnant les résultats
             resultAnalyse = resultList.stream().reduce((res1, res2) -> res1.thenCombineAsync(res2, biFunction, asyncExecutor)).orElse(CompletableFuture.completedFuture(new ResultAnalyse())).join();
         } else {
             resultAnalyse = ruleService.checkRulesOnNotices(requestBody.getId(), rulesToApply, requestBody.getPpnList(), requestBody.isReplayed()).join();
@@ -154,6 +224,11 @@ public class RuleController {
         return responseDto;
     }
 
+    private void cleanupAnalysis(Integer id) {
+        analysisResultsById.remove(id);
+        mapIdToNbTotalPpn.remove(id);
+        ruleService.clearCn(id);
+    }
 
     @PostMapping(value = "/indexRules", consumes = {"application/x-yaml", "application/yaml", "text/yaml", "text/yml"})
     public void indexRules(@Valid @RequestBody ListRulesWebDto rules) {
@@ -161,7 +236,6 @@ public class RuleController {
         try {
             ruleService.saveAll(rulesEntity);
         } catch (DataIntegrityViolationException ex) {
-            //exception levée dans le cas ou un id est déjà pris
             throw new IllegalArgumentException("Une règle avec l'identifiant " + StringUtils.substringBetween(ex.getMessage(), "#", "]") + " existe déjà");
         }
     }
@@ -169,37 +243,49 @@ public class RuleController {
     private List<ComplexRule> handleRulesWebDto(ListRulesWebDto rules) {
         List<ComplexRule> rulesEntity = new ArrayList<>();
         for (SimpleRuleWebDto rule : rules.getRules()) {
-            if (rule instanceof DependencyWebDto)
+            if (rule instanceof DependencyWebDto) {
                 throw new IllegalArgumentException("Une règle simple ne peut pas être une règle de dépendance");
-            if (rule instanceof ReciprociteWebDto)
+            }
+            if (rule instanceof ReciprociteWebDto) {
                 throw new IllegalArgumentException("Une règle simple ne peut pas être de type reciprocite");
+            }
             List<String> zonesGeneriques = referenceService.getZonesGeneriques(rule.getZone());
-//            List<String> zonesGeneriquesCible = (rule instanceof ComparaisonDateWebDto) ? referenceService.getZonesGeneriques(((ComparaisonDateWebDto) rule).getZoneCible()) : null;
             if (!zonesGeneriques.isEmpty()) {
                 int indexForGeneratingId = 0;
                 for (String zoneGenerique : zonesGeneriques) {
-                    if (rule instanceof PresenceZoneWebDto)
+                    if (rule instanceof PresenceZoneWebDto) {
                         rulesEntity.add(mapper.map(new PresenceZoneWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((PresenceZoneWebDto) rule).isPresent()), ComplexRule.class));
-                    if (rule instanceof PresenceSousZoneWebDto)
+                    }
+                    if (rule instanceof PresenceSousZoneWebDto) {
                         rulesEntity.add(mapper.map(new PresenceSousZoneWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((PresenceSousZoneWebDto) rule).getSousZone(), ((PresenceSousZoneWebDto) rule).isPresent()), ComplexRule.class));
-                    if (rule instanceof PresenceSousZonesMemeZoneWebDto)
+                    }
+                    if (rule instanceof PresenceSousZonesMemeZoneWebDto) {
                         rulesEntity.add(mapper.map(new PresenceSousZonesMemeZoneWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((PresenceSousZonesMemeZoneWebDto) rule).getSousZones()), ComplexRule.class));
-                    if (rule instanceof PositionSousZoneWebDto)
+                    }
+                    if (rule instanceof PositionSousZoneWebDto) {
                         rulesEntity.add(mapper.map(new PositionSousZoneWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((PositionSousZoneWebDto) rule).getSousZone(), ((PositionSousZoneWebDto) rule).getPositions(), ((PositionSousZoneWebDto) rule).getBooleanOperateur()), ComplexRule.class));
-                    if (rule instanceof NombreZoneWebDto)
+                    }
+                    if (rule instanceof NombreZoneWebDto) {
                         rulesEntity.add(mapper.map(new NombreZoneWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((NombreZoneWebDto) rule).getComparaisonOperateur(), ((NombreZoneWebDto) rule).getOccurrences()), ComplexRule.class));
-                    if (rule instanceof NombreSousZoneWebDto)
+                    }
+                    if (rule instanceof NombreSousZoneWebDto) {
                         rulesEntity.add(mapper.map(new NombreSousZoneWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((NombreSousZoneWebDto) rule).getSousZone(), ((NombreSousZoneWebDto) rule).getZoneCible(), ((NombreSousZoneWebDto) rule).getSousZoneCible()), ComplexRule.class));
-                    if (rule instanceof TypeCaractereWebDto)
+                    }
+                    if (rule instanceof TypeCaractereWebDto) {
                         rulesEntity.add(mapper.map(new TypeCaractereWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((TypeCaractereWebDto) rule).getSousZone(), ((TypeCaractereWebDto) rule).getTypeCaracteres()), ComplexRule.class));
-                    if (rule instanceof PresenceChaineCaracteresWebDto)
+                    }
+                    if (rule instanceof PresenceChaineCaracteresWebDto) {
                         rulesEntity.add(mapper.map(new PresenceChaineCaracteresWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((PresenceChaineCaracteresWebDto) rule).getSousZone(), ((PresenceChaineCaracteresWebDto) rule).getPositionStart(), ((PresenceChaineCaracteresWebDto) rule).getPositionEnd(), ((PresenceChaineCaracteresWebDto) rule).getTypeDeVerification(), ((PresenceChaineCaracteresWebDto) rule).getListChaineCaracteres()), ComplexRule.class));
-                    if (rule instanceof NombreCaracteresWebDto)
+                    }
+                    if (rule instanceof NombreCaracteresWebDto) {
                         rulesEntity.add(mapper.map(new NombreCaracteresWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, ((NombreCaracteresWebDto) rule).getSousZone(), rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((NombreCaracteresWebDto) rule).getComparaisonOperateur(), ((NombreCaracteresWebDto) rule).getOccurrences()), ComplexRule.class));
-                    if (rule instanceof IndicateurWebDto)
+                    }
+                    if (rule instanceof IndicateurWebDto) {
                         rulesEntity.add(mapper.map(new IndicateurWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((IndicateurWebDto) rule).getIndicateur(), ((IndicateurWebDto) rule).getValeur(), ((IndicateurWebDto) rule).getTypeDeVerification()), ComplexRule.class));
-                    if (rule instanceof ComparaisonDateWebDto)
+                    }
+                    if (rule instanceof ComparaisonDateWebDto) {
                         rulesEntity.add(mapper.map(new ComparaisonDateWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((ComparaisonDateWebDto) rule).getSousZone(), ((ComparaisonDateWebDto) rule).getPositionStart(), ((ComparaisonDateWebDto) rule).getPositionEnd(), ((ComparaisonDateWebDto) rule).getZoneCible(), ((ComparaisonDateWebDto) rule).getSousZoneCible(), ((ComparaisonDateWebDto) rule).getPositionStartCible(), ((ComparaisonDateWebDto) rule).getPositionEndCible(),((ComparaisonDateWebDto) rule).getComparateur()), ComplexRule.class));
+                    }
                     if (rule instanceof ComparaisonContenuSousZoneWebDto) {
                         if (((ComparaisonContenuSousZoneWebDto) rule).getNombreCaracteres() != null) {
                             rulesEntity.add(mapper.map(new ComparaisonContenuSousZoneWebDto(generateNewId(rule.getId(), indexForGeneratingId), rule.getIdExcel(), rule.getRuleSetList(), rule.getMessage(), rule.isAffichageEtiquette(), zoneGenerique, rule.getPriority(), rule.getTypesDoc(), rule.getTypesThese(), ((ComparaisonContenuSousZoneWebDto) rule).getSousZone(), ((ComparaisonContenuSousZoneWebDto) rule).getTypeVerification(), ((ComparaisonContenuSousZoneWebDto) rule).getNombreCaracteres(), ((ComparaisonContenuSousZoneWebDto) rule).getZoneCible(), ((ComparaisonContenuSousZoneWebDto) rule).getSousZoneCible()), ComplexRule.class));
@@ -256,16 +342,17 @@ public class RuleController {
         return mapper.mapList(ruleService.getAllComplexRules(), RuleWebDto.class);
     }
 
-    /**
-     * Methode pour la bar de progress
-     * @return pourcentage de progression
-     */
     @GetMapping("/getStatus/{id}")
     public String getStatus(@PathVariable int id) {
-        if(ruleService.isCnPresent(id)) {
-            return String.format("%.0f%%", ruleService.getCn(id, mapIdToNbTotalPpn.get(id)));
-        } else {
-            throw new IllegalArgumentException("L'identifiant pour obtenir le status de progression est incorrecte, Actualiser votre page");
+        CompletableFuture<ResultAnalyseResponseDto> analysisFuture = analysisResultsById.get(id);
+        if (analysisFuture != null && analysisFuture.isDone()) {
+            return "100%";
         }
+
+        if(ruleService.isCnPresent(id) && mapIdToNbTotalPpn.containsKey(id)) {
+            return String.format("%.0f%%", ruleService.getCn(id, mapIdToNbTotalPpn.get(id)));
+        }
+
+        throw new IllegalArgumentException("L'identifiant pour obtenir le status de progression est incorrecte, Actualiser votre page");
     }
 }

--- a/web/src/main/java/fr/abes/qualimarc/web/dto/AnalysisLaunchResponseDto.java
+++ b/web/src/main/java/fr/abes/qualimarc/web/dto/AnalysisLaunchResponseDto.java
@@ -1,0 +1,12 @@
+package fr.abes.qualimarc.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AnalysisLaunchResponseDto {
+    @JsonProperty("id")
+    private Integer id;
+}

--- a/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/controller/RuleControllerTest.java
@@ -22,12 +22,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -36,13 +38,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(classes = {RuleController.class}) //  Active le Model-View-Controller, nécessaire pour éviter le code d'erreur 415 lors du lancement du test checkPpn
+@SpringBootTest(classes = {RuleController.class})
 @ExtendWith({SpringExtension.class})
 @ContextConfiguration(classes = {WebConfig.class, AsyncConfiguration.class, ExceptionControllerHandler.class})
 public class RuleControllerTest {
@@ -78,10 +82,8 @@ public class RuleControllerTest {
     @MockitoBean
     UtilsMapper utilsMapper;
 
-
     @BeforeEach
     void init() {
-        // Utiliser le contexte Web complet pour bénéficier des @ControllerAdvice et converters enregistrés
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .build();
@@ -89,41 +91,39 @@ public class RuleControllerTest {
 
     @Test
     void checkPpnWithOneThread() throws Exception {
-        //  Création de la liste de contrôle pour le Mockito
         ResultRulesResponseDto resultRulesResponseDto = new ResultRulesResponseDto();
         resultRulesResponseDto.setPpn("143519379");
         List<ResultRulesResponseDto> resultRulesResponseDtoList = new ArrayList<>();
         resultRulesResponseDtoList.add(resultRulesResponseDto);
         ResultAnalyseResponseDto resultAnalyseResponseDto = new ResultAnalyseResponseDto();
         resultAnalyseResponseDto.setResultRules(resultRulesResponseDtoList);
-        //  Création du Mockito
+
         Mockito.doNothing().when(journalService).saveJournalAnalyse(Mockito.any());
-        Mockito.when(utilsMapper.map(any(),any())).thenReturn(resultAnalyseResponseDto);
+        Mockito.when(utilsMapper.map(any(), any())).thenReturn(resultAnalyseResponseDto);
         ResultAnalyse resultAnalyse = new ResultAnalyse();
         resultAnalyse.setPpnAnalyses(Sets.newLinkedHashSet("143519379"));
-        Mockito.when(ruleService.checkRulesOnNotices(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean())).thenReturn(CompletableFuture.completedFuture(resultAnalyse));
-        //  Création de l'objet ControllingPpnWithRuleSetsRequestDto à passer dans la requête
-        List<String> ppnList = new ArrayList<>();
-        ppnList.add("143519379");
-        TypeAnalyse typeAnalyse;
-        typeAnalyse = TypeAnalyse.QUICK;
-        PpnWithRuleSetsRequestDto ppnWithRuleSetsRequestDto = new PpnWithRuleSetsRequestDto();
-        ppnWithRuleSetsRequestDto.setPpnList(ppnList);
-        ppnWithRuleSetsRequestDto.setTypeAnalyse(typeAnalyse);
-        String jsonRequest = objectMapper.writeValueAsString(ppnWithRuleSetsRequestDto);
+        Mockito.when(ruleService.checkRulesOnNotices(Mockito.anyInt(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(CompletableFuture.completedFuture(resultAnalyse));
 
-        //  Appel et contrôle de la méthode
+        PpnWithRuleSetsRequestDto requestDto = new PpnWithRuleSetsRequestDto();
+        requestDto.setId(123);
+        requestDto.setPpnList(List.of("143519379"));
+        requestDto.setTypeAnalyse(TypeAnalyse.QUICK);
+
         this.mockMvc.perform(post("/api/v1/check")
                         .accept(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
-                        .content(jsonRequest))
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.id").value("123"));
+
+        waitForCompletedResult(123)
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultRules[0].ppn").value("143519379"));
     }
 
     @Test
     void checkPpnWitMultiThread() throws Exception {
-        //  Création de la liste de contrôle pour le Mockito
         List<ResultRulesResponseDto> resultRulesResponseDtoList = new ArrayList<>();
         resultRulesResponseDtoList.add(new ResultRulesResponseDto("143519379", new ArrayList<>()));
         resultRulesResponseDtoList.add(new ResultRulesResponseDto("123456789", new ArrayList<>()));
@@ -132,31 +132,26 @@ public class RuleControllerTest {
         ResultAnalyseResponseDto resultAnalyseResponseDto = new ResultAnalyseResponseDto();
         resultAnalyseResponseDto.setResultRules(resultRulesResponseDtoList);
 
-        //  Création du Mockito
         Mockito.doNothing().when(journalService).saveJournalAnalyse(Mockito.any());
-        Mockito.when(utilsMapper.map(any(),any())).thenReturn(resultAnalyseResponseDto);
+        Mockito.when(utilsMapper.map(any(), any())).thenReturn(resultAnalyseResponseDto);
         ResultAnalyse resultAnalyse = new ResultAnalyse();
         resultAnalyse.setPpnAnalyses(Sets.newLinkedHashSet("143519379", "123456789", "987654321", "654987321"));
-        Mockito.when(ruleService.checkRulesOnNotices(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean())).thenReturn(CompletableFuture.completedFuture(resultAnalyse));
+        Mockito.when(ruleService.checkRulesOnNotices(Mockito.anyInt(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(CompletableFuture.completedFuture(resultAnalyse));
 
-        //  Création de l'objet ControllingPpnWithRuleSetsRequestDto à passer dans la requête
-        List<String> ppnList = new ArrayList<>();
-        ppnList.add("143519379");
-        ppnList.add("123456789");
-        ppnList.add("987654321");
-        ppnList.add("654987321");
-        TypeAnalyse typeAnalyse;
-        typeAnalyse = TypeAnalyse.QUICK;
-        PpnWithRuleSetsRequestDto ppnWithRuleSetsRequestDto = new PpnWithRuleSetsRequestDto();
-        ppnWithRuleSetsRequestDto.setPpnList(ppnList);
-        ppnWithRuleSetsRequestDto.setTypeAnalyse(typeAnalyse);
-        String jsonRequest = objectMapper.writeValueAsString(ppnWithRuleSetsRequestDto);
+        PpnWithRuleSetsRequestDto requestDto = new PpnWithRuleSetsRequestDto();
+        requestDto.setId(456);
+        requestDto.setPpnList(List.of("143519379", "123456789", "987654321", "654987321"));
+        requestDto.setTypeAnalyse(TypeAnalyse.QUICK);
 
-        //  Appel et contrôle de la méthode
         this.mockMvc.perform(post("/api/v1/check")
-                .accept(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
-                .contentType(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
-                .content(jsonRequest))
+                        .accept(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.id").value("456"));
+
+        waitForCompletedResult(456)
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultRules[0].ppn").value("143519379"))
                 .andExpect(jsonPath("$.resultRules[1].ppn").value("123456789"))
@@ -173,8 +168,11 @@ public class RuleControllerTest {
 
         ResultAnalyse resultAnalyse = new ResultAnalyse();
         resultAnalyse.setPpnAnalyses(Sets.newLinkedHashSet("143519379", "123456789", "987654321", "654987321"));
-        Mockito.when(ruleService.checkRulesOnNotices(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
-                .thenReturn(CompletableFuture.completedFuture(resultAnalyse));
+        Mockito.when(ruleService.checkRulesOnNotices(Mockito.anyInt(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(
+                        CompletableFuture.completedFuture(resultAnalyse),
+                        CompletableFuture.completedFuture(resultAnalyse)
+                );
 
         PpnWithRuleSetsRequestDto request = new PpnWithRuleSetsRequestDto();
         request.setId(42);
@@ -185,10 +183,47 @@ public class RuleControllerTest {
                         .accept(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
                         .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.id").value("42"));
+
+        waitForCompletedResult(42)
                 .andExpect(status().isOk());
 
         Mockito.verify(ruleService, Mockito.times(1))
                 .getResultRulesList(Mockito.eq(TypeAnalyse.QUICK), Mockito.anySet(), Mockito.anySet(), Mockito.anySet());
+    }
+
+    @Test
+    void getResultReturnsAcceptedWhileAnalysisStillRunning() throws Exception {
+        ResultAnalyse resultAnalyse = new ResultAnalyse();
+        ResultAnalyseResponseDto resultAnalyseResponseDto = new ResultAnalyseResponseDto();
+
+        Mockito.doNothing().when(journalService).saveJournalAnalyse(Mockito.any());
+        Mockito.when(utilsMapper.map(any(), any())).thenReturn(resultAnalyseResponseDto);
+        Mockito.when(ruleService.checkRulesOnNotices(Mockito.anyInt(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(CompletableFuture.supplyAsync(
+                        () -> resultAnalyse,
+                        CompletableFuture.delayedExecutor(2, TimeUnit.SECONDS)
+                ));
+
+        PpnWithRuleSetsRequestDto requestDto = new PpnWithRuleSetsRequestDto();
+        requestDto.setId(789);
+        requestDto.setPpnList(List.of("143519379"));
+        requestDto.setTypeAnalyse(TypeAnalyse.QUICK);
+
+        this.mockMvc.perform(post("/api/v1/check")
+                        .accept(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.id").value("789"));
+
+        this.mockMvc.perform(get("/api/v1/result/789")
+                        .accept(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isAccepted());
+
+        waitForCompletedResult(789)
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -268,35 +303,7 @@ public class RuleControllerTest {
                 "         presence: true\n" +
                 "         operateur-booleen: ET\n";
 
-
-
-
         this.mockMvc.perform(post("/api/v1/indexComplexRules")
-                .contentType("application/x-yaml").characterEncoding(StandardCharsets.UTF_8)
-                .content(yaml).characterEncoding(StandardCharsets.UTF_8))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("test creation regle complexe presencesouszonesmemezone avec affichage-etiquette sur une sous-zone")
-    void testIndexComplexRulePresenceSousZonesMemeZoneWithSousZoneAffichageEtiquette() throws Exception {
-        String yaml =
-                "rules:\n" +
-                "   - id: 605\n" +
-                "     id-excel: 433\n" +
-                "     type: presencesouszonesmemezone\n" +
-                "     message: test 6XX sous-zone cachee\n" +
-                "     zone: '6XX'\n" +
-                "     priorite: P1\n" +
-                "     souszones:\n" +
-                "       - souszone: '2'\n" +
-                "         presence: false\n" +
-                "       - souszone: 'a'\n" +
-                "         presence: true\n" +
-                "         affichage-etiquette: false\n" +
-                "         operateur-booleen: ET\n";
-
-        this.mockMvc.perform(post("/api/v1/indexRules")
                 .contentType("application/x-yaml").characterEncoding(StandardCharsets.UTF_8)
                 .content(yaml).characterEncoding(StandardCharsets.UTF_8))
                 .andExpect(status().isOk());
@@ -371,4 +378,30 @@ public class RuleControllerTest {
                 .andExpect(status().isOk());
     }
 
+    private ResultAction waitForCompletedResult(int id) throws Exception {
+        MvcResult result = null;
+        for (int i = 0; i < 200; i++) {
+            result = this.mockMvc.perform(get("/api/v1/result/" + id)
+                    .accept(MediaType.APPLICATION_JSON_VALUE).characterEncoding(StandardCharsets.UTF_8))
+                    .andReturn();
+            if (result.getResponse().getStatus() != HttpStatus.ACCEPTED.value()) {
+                return new ResultAction(result);
+            }
+            Thread.sleep(50);
+        }
+        return new ResultAction(result);
+    }
+
+    private static class ResultAction {
+        private final MvcResult mvcResult;
+
+        private ResultAction(MvcResult mvcResult) {
+            this.mvcResult = mvcResult;
+        }
+
+        private ResultAction andExpect(org.springframework.test.web.servlet.ResultMatcher matcher) throws Exception {
+            matcher.match(this.mvcResult);
+            return this;
+        }
+    }
 }


### PR DESCRIPTION
## Objectif
- eviter les erreurs 502 sur les longues analyses en decouplant le lancement de l'analyse de la recuperation du resultat final

## Modifications
- transforme `POST /api/v1/check` en point de lancement asynchrone qui repond immediatement en `202`
- ajoute `GET /api/v1/result/{id}` pour recuperer le resultat final une fois l'analyse terminee
- stocke les executions en cours et les resultats par identifiant d'analyse
- fiabilise le suivi de progression avec des structures concurrentes et un nettoyage des analyses terminees
- adapte les tests du controleur au nouveau contrat asynchrone

## Verification
- `mvn test`