### PR TITLE
Supprime les warnings Spring et Hibernate au demarrage

### DIFF
--- a/batch/src/main/resources/application-dev.properties
+++ b/batch/src/main/resources/application-dev.properties
@@ -7,8 +7,6 @@ spring.datasource.qualimarc.password=
 spring.datasource.qualimarc.driver-class-name=org.postgresql.Driver
 
 spring.jpa.qualimarc.generate-ddl=true
-spring.jpa.qualimarc.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.qualimarc.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.qualimarc.hibernate.ddl-auto=none
 spring.jpa.qualimarc.show-sql=false
 spring.sql.qualimarc.init.mode=never

--- a/batch/src/main/resources/application-prod.properties
+++ b/batch/src/main/resources/application-prod.properties
@@ -7,8 +7,6 @@ spring.datasource.qualimarc.password=
 spring.datasource.qualimarc.driver-class-name=org.postgresql.Driver
 
 spring.jpa.qualimarc.generate-ddl=true
-spring.jpa.qualimarc.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.qualimarc.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.qualimarc.hibernate.ddl-auto=none
 spring.jpa.qualimarc.show-sql=false
 spring.sql.qualimarc.init.mode=never

--- a/batch/src/main/resources/application-test.properties
+++ b/batch/src/main/resources/application-test.properties
@@ -7,8 +7,6 @@ spring.datasource.qualimarc.password=
 spring.datasource.qualimarc.driver-class-name=org.postgresql.Driver
 
 spring.jpa.qualimarc.generate-ddl=true
-spring.jpa.qualimarc.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.qualimarc.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.qualimarc.hibernate.ddl-auto=none
 spring.jpa.qualimarc.show-sql=false
 spring.sql.qualimarc.init.mode=never

--- a/batch/src/test/java/fr/abes/qualimarc/batch/configuration/BatchJpaConfigurationContractTest.java
+++ b/batch/src/test/java/fr/abes/qualimarc/batch/configuration/BatchJpaConfigurationContractTest.java
@@ -1,0 +1,29 @@
+package fr.abes.qualimarc.batch.configuration;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BatchJpaConfigurationContractTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application-dev.properties",
+            "application-test.properties",
+            "application-prod.properties"
+    })
+    void profilePropertiesShouldNotForcePostgreSqlDialect(String profileProperties) throws IOException {
+        Properties properties = PropertiesLoaderUtils.loadProperties(new ClassPathResource(profileProperties));
+
+        assertThat(properties).doesNotContainKeys(
+                "spring.jpa.qualimarc.properties.hibernate.dialect",
+                "spring.jpa.qualimarc.database-platform"
+        );
+    }
+}

--- a/core/src/main/java/fr/abes/qualimarc/core/configuration/AbstractConfig.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/configuration/AbstractConfig.java
@@ -2,6 +2,7 @@ package fr.abes.qualimarc.core.configuration;
 
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.util.StringUtils;
 
 import java.util.HashMap;
 
@@ -11,12 +12,16 @@ public abstract class AbstractConfig {
                 = new HibernateJpaVendorAdapter();
         vendorAdapter.setGenerateDdl(generateDdl);
         vendorAdapter.setShowSql(showsql);
-        vendorAdapter.setDatabasePlatform(platform);
+        if (StringUtils.hasText(platform)) {
+            vendorAdapter.setDatabasePlatform(platform);
+        }
         em.setJpaVendorAdapter(vendorAdapter);
         HashMap<String, Object> properties = new HashMap<>();
         properties.put("hibernate.format_sql", true);
         properties.put("hibernate.hbm2ddl.auto", ddlAuto);
-        properties.put("hibernate.dialect", dialect);
+        if (StringUtils.hasText(dialect)) {
+            properties.put("hibernate.dialect", dialect);
+        }
         properties.put("logging.level.org.hibernate", "DEBUG");
         properties.put("hibernate.type", "trace");
         properties.put("spring.sql.init.mode", initMode);

--- a/core/src/main/java/fr/abes/qualimarc/core/configuration/QualimarcDbConfig.java
+++ b/core/src/main/java/fr/abes/qualimarc/core/configuration/QualimarcDbConfig.java
@@ -27,11 +27,11 @@ import javax.sql.DataSource;
 public class QualimarcDbConfig extends AbstractConfig {
     @Value("${spring.jpa.qualimarc.show-sql}")
     protected boolean showsql;
-    @Value("${spring.jpa.qualimarc.properties.hibernate.dialect}")
+    @Value("${spring.jpa.qualimarc.properties.hibernate.dialect:}")
     protected String dialect;
     @Value("${spring.jpa.qualimarc.hibernate.ddl-auto}")
     protected String ddlAuto;
-    @Value("${spring.jpa.qualimarc.database-platform}")
+    @Value("${spring.jpa.qualimarc.database-platform:}")
     protected String platform;
     @Value("${spring.jpa.qualimarc.generate-ddl}")
     protected boolean generateDdl;
@@ -68,7 +68,7 @@ public class QualimarcDbConfig extends AbstractConfig {
 
     @Primary
     @Bean
-    public PersistenceExceptionTranslationPostProcessor exceptionTranslation() {
+    public static PersistenceExceptionTranslationPostProcessor exceptionTranslation() {
         return new PersistenceExceptionTranslationPostProcessor();
     }
 

--- a/core/src/test/java/fr/abes/qualimarc/core/configuration/QualimarcDbConfigContractTest.java
+++ b/core/src/test/java/fr/abes/qualimarc/core/configuration/QualimarcDbConfigContractTest.java
@@ -1,0 +1,18 @@
+package fr.abes.qualimarc.core.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QualimarcDbConfigContractTest {
+
+    @Test
+    void exceptionTranslationBeanShouldBeDeclaredStatic() throws NoSuchMethodException {
+        Method exceptionTranslation = QualimarcDbConfig.class.getDeclaredMethod("exceptionTranslation");
+
+        assertThat(Modifier.isStatic(exceptionTranslation.getModifiers())).isTrue();
+    }
+}

--- a/web/src/main/resources/application-dev.properties
+++ b/web/src/main/resources/application-dev.properties
@@ -9,9 +9,7 @@ spring.datasource.qualimarc.driver-class-name=org.postgresql.Driver
 
 spring.jpa.qualimarc.generate-ddl=true
 spring.jpa.qualimarc.show-sql=false
-spring.jpa.qualimarc.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.qualimarc.hibernate.ddl-auto=create
-spring.jpa.qualimarc.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.sql.qualimarc.init.mode=always
 
 spring.datasource.basexml.jdbcurl=

--- a/web/src/main/resources/application-prod.properties
+++ b/web/src/main/resources/application-prod.properties
@@ -9,9 +9,7 @@ spring.datasource.qualimarc.driver-class-name=org.postgresql.Driver
 
 spring.jpa.qualimarc.generate-ddl=false
 spring.jpa.qualimarc.show-sql=false
-spring.jpa.qualimarc.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.qualimarc.hibernate.ddl-auto=update
-spring.jpa.qualimarc.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.sql.qualimarc.init.mode=never
 
 

--- a/web/src/main/resources/application-test.properties
+++ b/web/src/main/resources/application-test.properties
@@ -9,9 +9,7 @@ spring.datasource.qualimarc.driver-class-name=org.postgresql.Driver
 
 spring.jpa.qualimarc.generate-ddl=true
 spring.jpa.qualimarc.show-sql=false
-spring.jpa.qualimarc.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.qualimarc.hibernate.ddl-auto=update
-spring.jpa.qualimarc.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.sql.qualimarc.init.mode=always
 
 

--- a/web/src/test/java/fr/abes/qualimarc/web/configuration/WebJpaConfigurationContractTest.java
+++ b/web/src/test/java/fr/abes/qualimarc/web/configuration/WebJpaConfigurationContractTest.java
@@ -1,0 +1,29 @@
+package fr.abes.qualimarc.web.configuration;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebJpaConfigurationContractTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application-dev.properties",
+            "application-test.properties",
+            "application-prod.properties"
+    })
+    void profilePropertiesShouldNotForcePostgreSqlDialect(String profileProperties) throws IOException {
+        Properties properties = PropertiesLoaderUtils.loadProperties(new ClassPathResource(profileProperties));
+
+        assertThat(properties).doesNotContainKeys(
+                "spring.jpa.qualimarc.properties.hibernate.dialect",
+                "spring.jpa.qualimarc.database-platform"
+        );
+    }
+}


### PR DESCRIPTION
## Objectif
Supprimer les warnings Spring et Hibernate observes au demarrage de Qualimarc.

## Contenu
- rend le bean `PersistenceExceptionTranslationPostProcessor` statique
- rend optionnelle la declaration explicite du dialecte PostgreSQL pour Qualimarc
- retire les proprietes PostgreSQL redondantes des profils `web` et `batch`
- ajoute des tests de contrat pour verrouiller ce comportement

## Verification
- `mvn -pl core -Dtest=QualimarcDbConfigContractTest test`
- `mvn -pl batch -Dtest=BatchJpaConfigurationContractTest test`
- `mvn --% -pl web -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=WebJpaConfigurationContractTest test`
- `mvn -DskipTests package`